### PR TITLE
feat(stylelint-config): exclude `mask` & `mask-image` properties for `color-named` rule

### DIFF
--- a/projects/stylelint-config/index.js
+++ b/projects/stylelint-config/index.js
@@ -53,7 +53,12 @@ module.exports = {
         ],
         'color-hex-alpha': 'never',
         'color-hex-length': 'short',
-        'color-named': 'never',
+        'color-named': [
+            'never',
+            {
+                ignoreProperties: ['mask', 'mask-image'],
+            },
+        ],
         'color-no-invalid-hex': true,
         'comment-no-empty': true,
         'comment-whitespace-inside': 'always',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8ded06a4-01be-49c3-9f79-59736601b217)
