### PR TITLE
fix(eslint-plugin-experience-next): remove `properties.standalone` condition for standalone import

### DIFF
--- a/projects/eslint-plugin-experience-next/rules/standalone-imports-sort.ts
+++ b/projects/eslint-plugin-experience-next/rules/standalone-imports-sort.ts
@@ -19,7 +19,7 @@ const config: Rule.RuleModule = {
                             return mappings;
                         }, {});
 
-                        if (properties.standalone && properties.imports) {
+                        if (properties.imports) {
                             const currentOrder = properties.imports.value.elements.map(
                                 (prop: any) => prop.name,
                             );


### PR DESCRIPTION
…ndition for standalone import

Fixes # <!-- link to a relevant issue. -->
