### PR TITLE
feat(oxlint-config): add oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "extends": ["./node_modules/@taiga-ui/oxlint-config/.oxlintrc.json"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,13 +25,15 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@altano/repository-tools/-/repository-tools-2.0.1.tgz",
             "integrity": "sha512-YE/52CkFtb+YtHPgbWPai7oo5N9AKnMuP5LM+i2AG7G1H2jdYBCO1iDnkDE3dZ3C1MIgckaF+d5PNRulgt0bdw==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -45,6 +47,7 @@
             "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.15.tgz",
             "integrity": "sha512-HmGnUTLVwpvOFilc3gTP6CL9o+UbkVyu9S4WENkQbInbW3zp54lkzY71uWJIP7QvuXPa+bS4WHEmoGNQtNvv1A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/core": "20.3.15",
                 "rxjs": "7.8.2"
@@ -60,6 +63,7 @@
             "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.15.tgz",
             "integrity": "sha512-s7sE4S5Hy62dLrtHwizbZaMcupAE8fPhm6rF+jBkhHZ75zXGhGzXP8WKFztYCAuGnis4pPnGSEKP/xVTc2lw6Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "8.17.1",
                 "ajv-formats": "3.0.1",
@@ -87,6 +91,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -102,19 +107,22 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular-devkit/core/node_modules/jsonc-parser": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular-devkit/core/node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -127,6 +135,7 @@
             "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.15.tgz",
             "integrity": "sha512-xMN1fyuhhP8Y5sNlmQvl4nMiOouHTKPkLR0zlhu5z6fHuwxxlverh31Gpq3eFzPHqmOzzb2TkgYCptCFXsXcrg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/core": "20.3.15",
                 "jsonc-parser": "3.3.1",
@@ -144,13 +153,15 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular-devkit/schematics/node_modules/magic-string": {
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
             "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
@@ -160,6 +171,7 @@
             "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-20.7.0.tgz",
             "integrity": "sha512-qgf4Cfs1z0VsVpzF/OnxDRvBp60OIzeCsp4mzlckWYVniKo19EPIN6kFDol5eTAIOMPgiBQlMIwgQMHgocXEig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/architect": ">= 0.2000.0 < 0.2100.0",
                 "@angular-devkit/core": ">= 20.0.0 < 21.0.0"
@@ -173,13 +185,15 @@
             "version": "20.7.0",
             "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-20.7.0.tgz",
             "integrity": "sha512-9KPz24YoiL0SvTtTX6sd1zmysU5cKOCcmpEiXkCoO3L2oYZGlVxmMT4hfSaHMt8qmfvV2KzQMoR6DZM84BwRzQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular-eslint/eslint-plugin": {
             "version": "20.7.0",
             "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-20.7.0.tgz",
             "integrity": "sha512-aHH2YTiaonojsKN+y2z4IMugCwdsH/dYIjYBig6kfoSPyf9rGK4zx+gnNGq/pGRjF3bOYrmFgIviYpQVb80inQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "20.7.0",
                 "@angular-eslint/utils": "20.7.0",
@@ -196,6 +210,7 @@
             "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-20.7.0.tgz",
             "integrity": "sha512-WFmvW2vBR6ExsSKEaActQTteyw6ikWyuJau9XmWEPFd+2eusEt/+wO21ybjDn3uc5FTp1IcdhfYy+U5OdDjH5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "20.7.0",
                 "@angular-eslint/utils": "20.7.0",
@@ -215,6 +230,7 @@
             "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-20.7.0.tgz",
             "integrity": "sha512-S0onfRipDUIL6gFGTFjiWwUDhi42XYrBoi3kJ3wBbKBeIgYv9SP1ppTKDD4ZoDaDU9cQE8nToX7iPn9ifMw6eQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-devkit/core": ">= 20.0.0 < 21.0.0",
                 "@angular-devkit/schematics": ">= 20.0.0 < 21.0.0",
@@ -230,6 +246,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -239,6 +256,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -266,6 +284,7 @@
             "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-20.7.0.tgz",
             "integrity": "sha512-B6EJHbsk2W/lnS3kS/gm56VGvX735419z/DzgbRDcOvqMGMLwD1ILzv5OTEcL1rzpnB0AHW+IxOu6y/aCzSNUA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "20.7.0"
             },
@@ -310,6 +329,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.16.tgz",
             "integrity": "sha512-l3xF/fXfJAl/UrNnH9Ufkr79myjMgXdHq1mmmph2UnpeqilRB1b8lC9sLBV9MipQHVn3dwocxMIvtrcryfOaXw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.28.3",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -342,6 +362,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
             "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -371,13 +392,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular/compiler-cli/node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -387,6 +410,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -399,6 +423,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -411,6 +436,7 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
             "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0",
@@ -424,19 +450,22 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular/compiler-cli/node_modules/emoji-regex": {
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@angular/compiler-cli/node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -449,6 +478,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -466,6 +496,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -481,6 +512,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
             "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.2.1",
                 "string-width": "^7.0.0",
@@ -498,6 +530,7 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
             "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
@@ -515,6 +548,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
             "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
@@ -1050,6 +1084,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
             "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1062,6 +1097,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
             "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1074,6 +1110,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
             "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -1086,6 +1123,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
             "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -1147,6 +1185,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
             "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -1159,6 +1198,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
             "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1186,6 +1226,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
             "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -1198,6 +1239,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1210,6 +1252,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
             "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -1222,6 +1265,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1234,6 +1278,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
             "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1246,6 +1291,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
             "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -1258,6 +1304,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
             "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -1273,6 +1320,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
             "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -2405,13 +2453,15 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cacheable/memory": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
             "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cacheable/utils": "^2.3.3",
                 "@keyv/bigmap": "^1.3.0",
@@ -2424,6 +2474,7 @@
             "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
             "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hashery": "^1.4.0",
                 "hookified": "^1.15.0"
@@ -2450,6 +2501,7 @@
             "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
             "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hashery": "^1.3.0",
                 "keyv": "^5.5.5"
@@ -2460,6 +2512,7 @@
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
             "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@keyv/serialize": "^1.1.1"
             }
@@ -2505,6 +2558,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.4.0.tgz",
             "integrity": "sha512-zShmKTF+sqyNOfAE0vKcqnpvVpG0YX8F9G/ZIQHI2CoKyK+PSdladXMSns400aZ5/QZs+0fN75B//3Q5CHw++w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.4.0",
                 "ajv": "^8.11.0"
@@ -2518,6 +2572,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2533,13 +2588,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@commitlint/ensure": {
             "version": "20.4.1",
             "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.4.1.tgz",
             "integrity": "sha512-WLQqaFx1pBooiVvBrA1YfJNFqZF8wS/YGOtr5RzApDbV9tQ52qT5VkTsY65hFTnXhW8PcDfZLaknfJTmPejmlw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.4.0",
                 "lodash.camelcase": "^4.3.0",
@@ -2557,6 +2614,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
             "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=v18"
             }
@@ -2566,6 +2624,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.4.0.tgz",
             "integrity": "sha512-i3ki3WR0rgolFVX6r64poBHXM1t8qlFel1G1eCBvVgntE3fCJitmzSvH5JD/KVJN/snz6TfaX2CLdON7+s4WVQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.4.0",
                 "picocolors": "^1.1.1"
@@ -2579,6 +2638,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.4.1.tgz",
             "integrity": "sha512-In5EO4JR1lNsAv1oOBBO24V9ND1IqdAJDKZiEpdfjDl2HMasAcT7oA+5BKONv1pRoLG380DGPE2W2RIcUwdgLA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.4.0",
                 "semver": "^7.6.0"
@@ -2592,6 +2652,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2604,6 +2665,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.4.1.tgz",
             "integrity": "sha512-g94LrGl/c6UhuhDQqNqU232aslLEN2vzc7MPfQTHzwzM4GHNnEAwVWWnh0zX8S5YXecuLXDwbCsoGwmpAgPWKA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/is-ignored": "^20.4.1",
                 "@commitlint/parse": "^20.4.1",
@@ -2619,6 +2681,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.4.0.tgz",
             "integrity": "sha512-Dauup/GfjwffBXRJUdlX/YRKfSVXsXZLnINXKz0VZkXdKDcaEILAi9oflHGbfydonJnJAbXEbF3nXPm9rm3G6A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/config-validator": "^20.4.0",
                 "@commitlint/execute-rule": "^20.0.0",
@@ -2666,6 +2729,7 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
             "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jiti": "^2.6.1"
             },
@@ -2683,6 +2747,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2692,6 +2757,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.0.tgz",
             "integrity": "sha512-B5lGtvHgiLAIsK5nLINzVW0bN5hXv+EW35sKhYHE8F7V9Uz1fR4tx3wt7mobA5UNhZKUNgB/+ldVMQE6IHZRyA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=v18"
             }
@@ -2701,6 +2767,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.4.1.tgz",
             "integrity": "sha512-XNtZjeRcFuAfUnhYrCY02+mpxwY4OmnvD3ETbVPs25xJFFz1nRo/25nHj+5eM+zTeRFvWFwD4GXWU2JEtoK1/w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.4.0",
                 "conventional-changelog-angular": "^8.1.0",
@@ -2715,6 +2782,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.4.0.tgz",
             "integrity": "sha512-QfpFn6/I240ySEGv7YWqho4vxqtPpx40FS7kZZDjUJ+eHxu3azfhy7fFb5XzfTqVNp1hNoI3tEmiEPbDB44+cg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/top-level": "^20.4.0",
                 "@commitlint/types": "^20.4.0",
@@ -2731,6 +2799,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.4.0.tgz",
             "integrity": "sha512-ay1KM8q0t+/OnlpqXJ+7gEFQNlUtSU5Gxr8GEwnVf2TPN3+ywc5DzL3JCxmpucqxfHBTFwfRMXxPRRnR5Ki20g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/config-validator": "^20.4.0",
                 "@commitlint/types": "^20.4.0",
@@ -2748,6 +2817,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2757,6 +2827,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.4.1.tgz",
             "integrity": "sha512-WtqypKEPbQEuJwJS4aKs0OoJRBKz1HXPBC9wRtzVNH68FLhPWzxXlF09hpUXM9zdYTpm4vAdoTGkWiBgQ/vL0g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@commitlint/ensure": "^20.4.1",
                 "@commitlint/message": "^20.4.0",
@@ -2772,6 +2843,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
             "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=v18"
             }
@@ -2781,6 +2853,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.0.tgz",
             "integrity": "sha512-NDzq8Q6jmFaIIBC/GG6n1OQEaHdmaAAYdrZRlMgW6glYWGZ+IeuXmiymDvQNXPc82mVxq2KiE3RVpcs+1OeDeA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0"
             },
@@ -2793,6 +2866,7 @@
             "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.4.0.tgz",
             "integrity": "sha512-aO5l99BQJ0X34ft8b0h7QFkQlqxC6e7ZPVmBKz13xM9O8obDaM1Cld4sQlJDXXU/VFuUzQ30mVtHjVz74TuStw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "conventional-commits-parser": "^6.2.1",
                 "picocolors": "^1.1.1"
@@ -2806,6 +2880,7 @@
             "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
             "integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@simple-libs/child-process-utils": "^1.0.0",
                 "@simple-libs/stream-utils": "^1.1.0",
@@ -2832,6 +2907,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2844,6 +2920,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-9.6.4.tgz",
             "integrity": "sha512-OIiPQuB7XQ6rnUv4KaCwHr9vNwbh6VZ4GfgQjcThT0oz0hkL6E5Ar3tq54K9jyqE9ylcHqpRuXUgnKgio6Hlig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/dict-ada": "^4.1.1",
                 "@cspell/dict-al": "^1.1.1",
@@ -2914,6 +2991,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-9.6.4.tgz",
             "integrity": "sha512-rGYSDnDWACrUyovfN8M/LM8CCFSKjYd2kehbNS7YMPk0Jk+rLk6sgt5WYu3ty45otXCkiO07bjUo/81wBLet7A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-types": "9.6.4"
             },
@@ -2926,6 +3004,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-9.6.4.tgz",
             "integrity": "sha512-exuqxV1IVfZkasg57ZjUbaHeZDd6Mdbsbe5FBT3+XaVnRij+wpY2oEW9+kIOL5MOQE3bgQKgu37iMtA1NlCrGA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.18"
             }
@@ -2935,6 +3014,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-9.6.4.tgz",
             "integrity": "sha512-vVxajTG9Ko01oHk8HPsMLajcLrd9AfkOk6vdgFI4FD7ZPq1CY0hfTmfmJ8bzZ4/QkqXglTvePdSgHQVJeltwWw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -2944,6 +3024,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-9.6.4.tgz",
             "integrity": "sha512-3xsgZEqqH9Uj8ZYLBnWbnsHz8wphgaeuWKcNDqgwoMjvwTMQLGoXjHht8Jx5yxd2e080lB7fJax8TaBdCzmFFA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "global-directory": "^4.0.1"
             },
@@ -2956,6 +3037,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-9.6.4.tgz",
             "integrity": "sha512-oGNEzP1gJ43rLklJQjOk5PsfX0mZkLjV19djGptb9xZQeC2qAUxnaAbZtWt5CE8ni2iiTaRmgNRbUqAhRCnjew==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -2975,6 +3057,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-9.6.4.tgz",
             "integrity": "sha512-anacKDOZzDfPzuDeFOXGI2tFBYiRRCSnIZP/AOyJ9zTvEQcqq5p/ak18nJ5OQyDr2NG7ovJiCDT5YNiH2Vdg/g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cspell-lib": "9.6.4"
             },
@@ -2986,13 +3069,15 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.1.1.tgz",
             "integrity": "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-al": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-al/-/dict-al-1.1.1.tgz",
             "integrity": "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-ar": {
             "version": "1.1.7",
@@ -3005,7 +3090,8 @@
             "version": "4.0.17",
             "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.17.tgz",
             "integrity": "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-bash": {
             "version": "4.2.2",
@@ -3021,7 +3107,8 @@
             "version": "3.2.10",
             "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.10.tgz",
             "integrity": "sha512-bJ1qnO1DkTn7JYGXvxp8FRQc4yq6tRXnrII+jbP8hHmq5TX5o1Wu+rdfpoUQaMWTl6balRvcMYiINDesnpR9Bw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-cpp": {
             "version": "7.0.2",
@@ -3041,7 +3128,8 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.8.tgz",
             "integrity": "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-css": {
             "version": "4.0.19",
@@ -3054,49 +3142,57 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.3.2.tgz",
             "integrity": "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-data-science": {
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.13.tgz",
             "integrity": "sha512-l1HMEhBJkPmw4I2YGVu2eBSKM89K9pVF+N6qIr5Uo5H3O979jVodtuwP8I7LyPrJnC6nz28oxeGRCLh9xC5CVA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-django": {
             "version": "4.1.6",
             "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.6.tgz",
             "integrity": "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-docker": {
             "version": "1.1.17",
             "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.17.tgz",
             "integrity": "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-dotnet": {
             "version": "5.0.11",
             "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.11.tgz",
             "integrity": "sha512-LSVKhpFf/ASTWJcfYeS0Sykcl1gVMsv2Z5Eo0TnTMSTLV3738HH+66pIsjUTChqU6SF3gKPuCe6EOaRYqb/evA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-elixir": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.8.tgz",
             "integrity": "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-en_us": {
             "version": "4.4.28",
             "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.28.tgz",
             "integrity": "sha512-/rzhbZaZDsDWmXbc9Fmmr4/ngmaNcG2b+TGT+ZjGqpOXVQYI75yZ9+XduyI43xJ5O38QcX3QIbJY5GWaJqxPEg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-en-common-misspellings": {
             "version": "2.1.12",
             "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.12.tgz",
             "integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw==",
-            "license": "CC BY-SA 4.0"
+            "license": "CC BY-SA 4.0",
+            "peer": true
         },
         "node_modules/@cspell/dict-en-gb": {
             "version": "5.0.22",
@@ -3109,19 +3205,22 @@
             "version": "3.1.17",
             "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.17.tgz",
             "integrity": "sha512-MLx+3XN9rj+EGwLIFmh0gpEDNalCyQqjcszp+WkedCHcvTCzQgWXQMZK6cPuhO/OKYyW9GOwsx4t0wjU5tRVNg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-filetypes": {
             "version": "3.0.15",
             "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.15.tgz",
             "integrity": "sha512-uDMeqYlLlK476w/muEFQGBy9BdQWS0mQ7BJiy/iQv5XUWZxE2O54ZQd9nW8GyQMzAgoyg5SG4hf9l039Qt66oA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-flutter": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-flutter/-/dict-flutter-1.1.1.tgz",
             "integrity": "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-fonts": {
             "version": "4.0.5",
@@ -3141,13 +3240,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-fsharp/-/dict-fsharp-1.1.1.tgz",
             "integrity": "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-fullstack": {
             "version": "3.2.8",
             "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.2.8.tgz",
             "integrity": "sha512-J6EeoeThvx/DFrcA2rJiCA6vfqwJMbkG0IcXhlsmRZmasIpanmxgt90OEaUazbZahFiuJT8wrhgQ1QgD1MsqBw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-gaming-terms": {
             "version": "1.1.2",
@@ -3160,25 +3261,29 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.1.0.tgz",
             "integrity": "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-golang": {
             "version": "6.0.26",
             "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
             "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-google": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@cspell/dict-google/-/dict-google-1.0.9.tgz",
             "integrity": "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-haskell": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.6.tgz",
             "integrity": "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-html": {
             "version": "4.0.14",
@@ -3198,31 +3303,36 @@
             "version": "5.0.12",
             "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.12.tgz",
             "integrity": "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-julia": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.1.1.tgz",
             "integrity": "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-k8s": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
             "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-kotlin": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-kotlin/-/dict-kotlin-1.1.1.tgz",
             "integrity": "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-latex": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-5.0.0.tgz",
             "integrity": "sha512-HUrIqUVohM6P0+5b7BsdAdb0STIv0aaFBvguI7pLcreljlcX3FSPUxea7ticzNlCNeVrEaiEn/ws9m6rYUeuNw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-lorem-ipsum": {
             "version": "4.0.5",
@@ -3235,19 +3345,22 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.8.tgz",
             "integrity": "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-makefile": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@cspell/dict-makefile/-/dict-makefile-1.0.5.tgz",
             "integrity": "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-markdown": {
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.14.tgz",
             "integrity": "sha512-uLKPNJsUcumMQTsZZgAK9RgDLyQhUz/uvbQTEkvF/Q4XfC1i/BnA8XrOrd0+Vp6+tPOKyA+omI5LRWfMu5K/Lw==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@cspell/dict-css": "^4.0.19",
                 "@cspell/dict-html": "^4.0.14",
@@ -3266,43 +3379,50 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.12.tgz",
             "integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-node": {
             "version": "5.0.9",
             "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.9.tgz",
             "integrity": "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-npm": {
             "version": "5.2.32",
             "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.32.tgz",
             "integrity": "sha512-H0XD0eg4d96vevle8VUKVoPhsgsw003ByJ47XzipyiMKoQTZ2IAUW+VTkQq8wU1floarNjmThQJOoKL9J4UYuw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-php": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.1.1.tgz",
             "integrity": "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-powershell": {
             "version": "5.0.15",
             "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.15.tgz",
             "integrity": "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-public-licenses": {
             "version": "2.0.15",
             "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.15.tgz",
             "integrity": "sha512-cJEOs901H13Pfy0fl4dCD1U+xpWIMaEPq8MeYU83FfDZvellAuSo4GqWCripfIqlhns/L6+UZEIJSOZnjgy7Wg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-python": {
             "version": "4.2.25",
             "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.25.tgz",
             "integrity": "sha512-hDdN0YhKgpbtZVRjQ2c8jk+n0wQdidAKj1Fk8w7KEHb3YlY5uPJ0mAKJk7AJKPNLOlILoUmN+HAVJz+cfSbWYg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/dict-data-science": "^2.0.13"
             }
@@ -3311,7 +3431,8 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.1.1.tgz",
             "integrity": "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-ru_ru": {
             "version": "2.3.2",
@@ -3324,7 +3445,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.0.tgz",
             "integrity": "sha512-9PJQB3cfkBULrMLp5kSAcFPpzf8oz9vFN+QYZABhQwWkGbuzCIXSorHrmWSASlx4yejt3brjaWS57zZ/YL5ZQQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-russian": {
             "version": "1.1.27",
@@ -3338,13 +3460,15 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.1.2.tgz",
             "integrity": "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-scala": {
             "version": "5.0.9",
             "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.9.tgz",
             "integrity": "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-scientific-terms-us": {
             "version": "3.1.0",
@@ -3357,37 +3481,43 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@cspell/dict-shell/-/dict-shell-1.1.2.tgz",
             "integrity": "sha512-WqOUvnwcHK1X61wAfwyXq04cn7KYyskg90j4lLg3sGGKMW9Sq13hs91pqrjC44Q+lQLgCobrTkMDw9Wyl9nRFA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-software-terms": {
             "version": "5.1.20",
             "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.20.tgz",
             "integrity": "sha512-TEk1xHvetTI4pv7Vzje1D322m6QEjaH2P6ucOOf6q7EJCppQIdC0lZSXkgHJAFU5HGSvEXSzvnVeW2RHW86ziQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-sql": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.2.1.tgz",
             "integrity": "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-svelte": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.7.tgz",
             "integrity": "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-swift": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.6.tgz",
             "integrity": "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-terraform": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
             "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-typescript": {
             "version": "3.2.3",
@@ -3400,19 +3530,22 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.5.tgz",
             "integrity": "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dict-zig": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@cspell/dict-zig/-/dict-zig-1.0.0.tgz",
             "integrity": "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@cspell/dynamic-import": {
             "version": "9.6.4",
             "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-9.6.4.tgz",
             "integrity": "sha512-1VnL9ahT3s17DLWl4MeO1pYg7zcVT3X9cKynI2/U86zNK5xMGS5icvjp7X65tsCAVNcWOtkqVFfrxi7kWxn67g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/url": "9.6.4",
                 "import-meta-resolve": "^4.2.0"
@@ -3426,6 +3559,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-9.6.4.tgz",
             "integrity": "sha512-a1aZ/8vGnhTknxTukjzo3m8CISyHW2MWnbedywg5SDEl5RMJitmzX90QZiQdSvEcqzqmtoAgSEZNBT2LX2gIKg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -3435,6 +3569,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-9.6.4.tgz",
             "integrity": "sha512-vGI1788Rx5Yml9N1/pD4zGd8Vrchi2Y01ADf9NiiOaNVVdf4PU1GCssLCsiIzhYQneErpQ8pJi/mS2F/QMZbRA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.18"
             }
@@ -3444,6 +3579,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-9.6.4.tgz",
             "integrity": "sha512-AQrUbA0JUOEQgwItnfUQ6Ydk0hWY/uV3VhLwZWyrnT9eiQynmTnRTHtOCkkSl9+M4P0N4Raa2eGFRLcPAFksaw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -3453,6 +3589,7 @@
             "resolved": "https://registry.npmjs.org/@cspell/url/-/url-9.6.4.tgz",
             "integrity": "sha512-h6VMlb7bDyGJfwLtipxxtHlT+ojzUXZz14AqZ/NEzY3LfOhfJTGpRcWLYFsgG/L0Ma4qjsYbPJt/Sj1C14j0VA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -3518,7 +3655,8 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "license": "MIT-0"
+            "license": "MIT-0",
+            "peer": true
         },
         "node_modules/@csstools/css-tokenizer": {
             "version": "4.0.0",
@@ -3555,6 +3693,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -3578,6 +3717,7 @@
                 }
             ],
             "license": "MIT-0",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -3600,6 +3740,7 @@
                 }
             ],
             "license": "MIT-0",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -3611,7 +3752,8 @@
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz",
             "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emnapi/core": {
             "version": "1.8.1",
@@ -3651,7 +3793,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3668,7 +3809,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3685,7 +3825,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3702,7 +3841,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3719,7 +3857,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3736,7 +3873,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3753,7 +3889,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3770,7 +3905,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3787,7 +3921,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3804,7 +3937,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3821,7 +3953,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3838,7 +3969,6 @@
             "cpu": [
                 "loong64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3855,7 +3985,6 @@
             "cpu": [
                 "mips64el"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3872,7 +4001,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3889,7 +4017,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3906,7 +4033,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3923,7 +4049,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3940,7 +4065,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3957,7 +4081,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3974,7 +4097,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3991,7 +4113,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4008,7 +4129,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4025,7 +4145,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4042,7 +4161,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4059,7 +4177,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4076,7 +4193,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4121,6 +4237,7 @@
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -4151,6 +4268,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
             "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
@@ -4165,6 +4283,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -4177,6 +4296,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
             "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.17.0"
             },
@@ -4189,6 +4309,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
             "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -4201,6 +4322,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
             "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -4213,6 +4335,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.8.tgz",
             "integrity": "sha512-s0f40zY7dlMp8i0Jf0u6l/aSswS0WRAgkhgETgiCJRcxIWb4S/Sp9uScKHWbkM3BnoFLbJbmOYk5AZUDFVxaLA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mdn-data": "2.23.0",
                 "source-map-js": "^1.0.1"
@@ -4226,6 +4349,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
             "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -4249,6 +4373,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
             "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4261,6 +4386,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -4273,6 +4399,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
             "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -4285,6 +4412,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-7.5.1.tgz",
             "integrity": "sha512-R8uZemG9dKTbru/DQRPblbJyXpObwKzo8rv1KYGGuPUPtjM4LXBYM9q5CIZAComzZupws3tWbDwam5AFpPLyJQ==",
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "examples/*"
             ],
@@ -4308,6 +4436,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
             "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -4320,6 +4449,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
             "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -4329,6 +4459,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
             "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.17.0",
                 "levn": "^0.4.1"
@@ -4342,6 +4473,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
             "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -4388,6 +4520,7 @@
             "resolved": "https://registry.npmjs.org/@html-eslint/template-parser/-/template-parser-0.54.0.tgz",
             "integrity": "sha512-gSjgmGwRQehNxZ3XdRUhUoXDFzYc/LYoKA7JwExjdvklGnSh5WkH/CLOlphkDh9jJsC1O/E0I04bVGrzy3idKQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@html-eslint/types": "^0.54.0",
                 "es-html-parser": "0.3.1"
@@ -4398,6 +4531,7 @@
             "resolved": "https://registry.npmjs.org/@html-eslint/template-syntax-parser/-/template-syntax-parser-0.54.0.tgz",
             "integrity": "sha512-7mDM4AWqz42FHwnOt8Lu5xqovaZHlEuBrmwNrMg6VwC9TPaLVyh4j3zNzNnM6tjftaXZzverJup39zGB8mvXjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@html-eslint/types": "^0.54.0"
             }
@@ -4407,6 +4541,7 @@
             "resolved": "https://registry.npmjs.org/@html-eslint/types/-/types-0.54.0.tgz",
             "integrity": "sha512-bfJolxay0POMYaFWTCH1MBitEaxIEKZOoROGOLZiRBaPvQrzhwYQktuyt5X1PcHqUB4HwEtYgSdpjYGT4JbrvA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/css-tree": "^2.3.11",
                 "@types/estree": "^1.0.6",
@@ -4419,6 +4554,7 @@
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -4428,6 +4564,7 @@
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
             "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.4.0"
@@ -4441,6 +4578,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -4454,6 +4592,7 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -4467,6 +4606,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
             "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4476,6 +4616,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
             "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/ansi": "^1.0.2",
                 "@inquirer/core": "^10.3.2",
@@ -4500,6 +4641,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
             "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/type": "^3.0.10"
@@ -4521,6 +4663,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
             "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/ansi": "^1.0.2",
                 "@inquirer/figures": "^1.0.15",
@@ -4548,6 +4691,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -4560,6 +4704,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -4574,6 +4719,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
             "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/external-editor": "^1.0.3",
@@ -4596,6 +4742,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
             "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/type": "^3.0.10",
@@ -4618,6 +4765,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
             "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chardet": "^2.1.1",
                 "iconv-lite": "^0.7.0"
@@ -4639,6 +4787,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
             "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4648,6 +4797,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
             "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/type": "^3.0.10"
@@ -4669,6 +4819,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
             "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/type": "^3.0.10"
@@ -4690,6 +4841,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
             "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/ansi": "^1.0.2",
                 "@inquirer/core": "^10.3.2",
@@ -4712,6 +4864,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
             "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.3.2",
                 "@inquirer/confirm": "^5.1.21",
@@ -4741,6 +4894,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
             "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/type": "^3.0.10",
@@ -4763,6 +4917,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
             "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/core": "^10.3.2",
                 "@inquirer/figures": "^1.0.15",
@@ -4786,6 +4941,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
             "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/ansi": "^1.0.2",
                 "@inquirer/core": "^10.3.2",
@@ -4810,6 +4966,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
             "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4848,6 +5005,7 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
             "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -4864,6 +5022,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -4873,6 +5032,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -4886,6 +5046,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
             "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -4899,6 +5060,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -4911,6 +5073,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -4926,6 +5089,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -4938,6 +5102,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4947,6 +5112,7 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
             "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4956,6 +5122,7 @@
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
             "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -4973,6 +5140,7 @@
             "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
             "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/reporters": "^29.7.0",
@@ -5020,6 +5188,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -5031,13 +5200,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/core/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5056,6 +5227,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5065,6 +5237,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -5089,6 +5262,7 @@
             "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
             "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/fake-timers": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5104,6 +5278,7 @@
             "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
             "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "expect": "^29.7.0",
                 "jest-snapshot": "^29.7.0"
@@ -5117,6 +5292,7 @@
             "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
             "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jest-get-type": "^29.6.3"
             },
@@ -5129,6 +5305,7 @@
             "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
             "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -5156,6 +5333,7 @@
             "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
             "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -5171,6 +5349,7 @@
             "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
             "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "^29.7.0",
@@ -5215,6 +5394,7 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5235,6 +5415,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5260,6 +5441,7 @@
             "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
             "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.18",
                 "callsites": "^3.0.0",
@@ -5274,6 +5456,7 @@
             "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
             "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5289,6 +5472,7 @@
             "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
             "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "graceful-fs": "^4.2.9",
@@ -5304,6 +5488,7 @@
             "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
             "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/types": "^29.6.3",
@@ -5330,6 +5515,7 @@
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
             "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5347,6 +5533,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -5358,7 +5545,8 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
@@ -5409,13 +5597,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
             "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@mdn/browser-compat-data": {
             "version": "6.1.5",
             "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.1.5.tgz",
             "integrity": "sha512-PzdZZzRhcXvKB0begee28n5lvwAcinGKYuLZOVxHAZm+n7y01ddEGfdS1ZXRuVcV+ndG6mSEAE8vgudom5UjYg==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.4",
@@ -5434,6 +5624,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -5447,6 +5638,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -5456,6 +5648,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -5469,6 +5662,7 @@
             "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
             "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "lodash": "^4.15.0"
             }
@@ -5763,6 +5957,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
             "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 20"
             }
@@ -5791,6 +5986,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
             "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/types": "^16.0.0",
                 "universal-user-agent": "^7.0.2"
@@ -5804,6 +6000,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
             "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/request": "^10.0.6",
                 "@octokit/types": "^16.0.0",
@@ -5817,13 +6014,15 @@
             "version": "27.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
             "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
             "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/types": "^16.0.0"
             },
@@ -5839,6 +6038,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
             "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 20"
             },
@@ -5851,6 +6051,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
             "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/types": "^16.0.0"
             },
@@ -5866,6 +6067,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
             "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/endpoint": "^11.0.2",
                 "@octokit/request-error": "^7.0.2",
@@ -5882,6 +6084,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
             "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/types": "^16.0.0"
             },
@@ -5894,6 +6097,7 @@
             "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
             "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/core": "^7.0.6",
                 "@octokit/plugin-paginate-rest": "^14.0.0",
@@ -5909,15 +6113,129 @@
             "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
             "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/openapi-types": "^27.0.0"
             }
+        },
+        "node_modules/@oxlint/darwin-arm64": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.43.0.tgz",
+            "integrity": "sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/darwin-x64": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.43.0.tgz",
+            "integrity": "sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/linux-arm64-gnu": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.43.0.tgz",
+            "integrity": "sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/linux-arm64-musl": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.43.0.tgz",
+            "integrity": "sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/linux-x64-gnu": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.43.0.tgz",
+            "integrity": "sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/linux-x64-musl": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.43.0.tgz",
+            "integrity": "sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/win32-arm64": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.43.0.tgz",
+            "integrity": "sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
+        },
+        "node_modules/@oxlint/win32-x64": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.43.0.tgz",
+            "integrity": "sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true
         },
         "node_modules/@phun-ky/typeof": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@phun-ky/typeof/-/typeof-2.0.3.tgz",
             "integrity": "sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^20.9.0 || >=22.0.0",
                 "npm": ">=10.8.2"
@@ -5931,6 +6249,7 @@
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
             "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -5956,6 +6275,7 @@
             "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-10.0.5.tgz",
             "integrity": "sha512-Dxul3YlUsDLbIg+aR6T0QR/VyKwuJNR3GZM8mKVEwFO8GpH2H5vgnN7kacEvq/Qk5puDadOVbhbUq/KBjraemQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@conventional-changelog/git-client": "^2.5.1",
                 "concat-stream": "^2.0.0",
@@ -5977,6 +6297,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -6509,13 +6830,15 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@simple-libs/child-process-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.1.tgz",
             "integrity": "sha512-3nWd8irxvDI6v856wpPCHZ+08iQR0oHTZfzAZmnbsLzf+Sf1odraP6uKOHDZToXq3RPRV/LbqGVlSCogm9cJjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@simple-libs/stream-utils": "^1.1.0",
                 "@types/node": "^22.0.0"
@@ -6532,6 +6855,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
             "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -6540,13 +6864,15 @@
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@simple-libs/stream-utils": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.1.0.tgz",
             "integrity": "sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^22.0.0"
             },
@@ -6562,6 +6888,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
             "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -6570,7 +6897,8 @@
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.48",
@@ -6584,6 +6912,7 @@
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
             "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -6596,6 +6925,7 @@
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
             "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
@@ -6605,6 +6935,7 @@
             "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
             "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
@@ -6628,6 +6959,7 @@
             "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.7.1.tgz",
             "integrity": "sha512-zjTUwIsEfT+k9BmXwq1QEFYsb4afBlsI1AXFyWQBgggMzwBFOuu92pGrE5OFx90IOjNl+lUbQoTG7f8S0PkOdg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/types": "^8.53.1",
@@ -6648,6 +6980,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6721,6 +7054,10 @@
             "resolved": "projects/jest-config",
             "link": true
         },
+        "node_modules/@taiga-ui/oxlint-config": {
+            "resolved": "projects/oxlint-config",
+            "link": true
+        },
         "node_modules/@taiga-ui/prettier-config": {
             "resolved": "projects/prettier-config",
             "link": true
@@ -6746,6 +7083,7 @@
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -6754,7 +7092,8 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.12",
@@ -6799,6 +7138,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
             "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -6812,6 +7152,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
             "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
@@ -6821,6 +7162,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
             "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -6831,6 +7173,7 @@
             "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
             "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
@@ -6839,13 +7182,15 @@
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
             "integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/debug": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -6854,7 +7199,8 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -6878,6 +7224,7 @@
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
             "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -6886,13 +7233,15 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
             "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
@@ -6902,6 +7251,7 @@
             "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
             "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
@@ -6911,6 +7261,7 @@
             "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
             "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "expect": "^29.0.0",
                 "pretty-format": "^29.0.0"
@@ -6921,6 +7272,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -6932,13 +7284,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/jest/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6951,6 +7305,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -6965,6 +7320,7 @@
             "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
             "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
@@ -6975,19 +7331,22 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
             "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
             "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -6996,13 +7355,15 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
             "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/ms": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/node": {
             "version": "25.2.1",
@@ -7018,13 +7379,15 @@
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/parse-author": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse-author/-/parse-author-2.0.3.tgz",
             "integrity": "sha512-pgRW2K/GVQoogylrGJXDl7PBLW9A6T4OOc9Hy9MLT5f7vgufK2GQ8FcfAbjFHR5HjcN9ByzuCczAORk49REqoA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -7036,7 +7399,8 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
             "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/resolve": {
             "version": "1.20.2",
@@ -7049,25 +7413,29 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/unist": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
             "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -7076,7 +7444,8 @@
             "version": "21.0.3",
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
             "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.54.0",
@@ -7112,6 +7481,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -7121,7 +7491,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -7239,6 +7608,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
             "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.54.0",
                 "@typescript-eslint/typescript-estree": "8.54.0",
@@ -7263,7 +7633,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
             "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -7340,7 +7709,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
             "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
                 "@typescript-eslint/scope-manager": "8.54.0",
@@ -7381,6 +7749,7 @@
             "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
             "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "chevrotain": "7.1.1"
             }
@@ -7448,14 +7817,14 @@
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "deprecated": "Use your platform's native atob() and btoa() methods instead",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7468,6 +7837,7 @@
             "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
             "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
@@ -7478,6 +7848,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -7509,6 +7880,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -7537,6 +7909,7 @@
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -7554,6 +7927,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -7569,7 +7943,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/angular-eslint": {
             "version": "20.7.0",
@@ -7609,6 +7984,7 @@
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
             "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -7648,6 +8024,7 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -7661,6 +8038,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -7686,6 +8064,7 @@
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
             "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7695,6 +8074,7 @@
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
             "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "is-array-buffer": "^3.0.5"
@@ -7711,6 +8091,7 @@
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
             "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7719,13 +8100,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
             "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/array-includes": {
             "version": "3.1.9",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
             "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -7747,13 +8130,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
             "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7763,6 +8148,7 @@
             "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
             "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
@@ -7784,6 +8170,7 @@
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
             "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -7802,6 +8189,7 @@
             "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
             "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -7820,6 +8208,7 @@
             "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
             "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
                 "call-bind": "^1.0.8",
@@ -7841,6 +8230,7 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7850,6 +8240,7 @@
             "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.1.tgz",
             "integrity": "sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@mdn/browser-compat-data": "^5.6.19"
             }
@@ -7858,13 +8249,15 @@
             "version": "5.7.6",
             "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.7.6.tgz",
             "integrity": "sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/ast-types": {
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -7877,6 +8270,7 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7893,6 +8287,7 @@
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
             "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7902,6 +8297,7 @@
             "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
             "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "retry": "0.13.1"
             }
@@ -7917,6 +8313,7 @@
             "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
             "integrity": "sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8"
             }
@@ -7926,6 +8323,7 @@
             "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.5.0.tgz",
             "integrity": "sha512-UTnLjT7I9U2U/xkCUH5buDlp8C7g0SGChfib+iDrJkamcj5kaMqNKHNfbKJw1kthJUq8sUo3i3q2S6FzO/l/wA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "commander": "^7.2.0",
                 "handlebars": "^4.7.7",
@@ -7946,6 +8344,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -7995,6 +8394,7 @@
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
             },
@@ -8022,6 +8422,7 @@
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -8031,6 +8432,7 @@
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
             "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/transform": "^29.7.0",
                 "@types/babel__core": "^7.1.14",
@@ -8067,6 +8469,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
             "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -8083,6 +8486,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
             "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.12.3",
                 "@babel/parser": "^7.14.7",
@@ -8099,6 +8503,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
             "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.3.3",
                 "@babel/types": "^7.3.3",
@@ -8115,7 +8520,6 @@
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -8183,6 +8587,7 @@
             "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
             "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -8209,6 +8614,7 @@
             "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
             "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "babel-plugin-jest-hoist": "^29.6.3",
                 "babel-preset-current-node-syntax": "^1.0.0"
@@ -8261,6 +8667,7 @@
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
             "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -8269,7 +8676,8 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
             "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/bl": {
             "version": "4.1.0",
@@ -8288,6 +8696,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8298,6 +8707,7 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -8324,7 +8734,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -8344,6 +8753,7 @@
             "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
             "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-json-stable-stringify": "2.x"
             },
@@ -8356,6 +8766,7 @@
             "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
             "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
@@ -8396,6 +8807,7 @@
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
             "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -8408,6 +8820,7 @@
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -8423,6 +8836,7 @@
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8432,6 +8846,7 @@
             "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
             "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": "^5.0.0",
                 "confbox": "^0.2.2",
@@ -8460,6 +8875,7 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -8475,6 +8891,7 @@
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
             "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8487,6 +8904,7 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
             "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 20.19.0"
             },
@@ -8500,6 +8918,7 @@
             "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
             "integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cacheable/memory": "^2.0.7",
                 "@cacheable/utils": "^2.3.3",
@@ -8513,6 +8932,7 @@
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
             "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@keyv/serialize": "^1.1.1"
             }
@@ -8522,6 +8942,7 @@
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
@@ -8553,6 +8974,7 @@
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -8578,6 +9000,7 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -8607,6 +9030,7 @@
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8633,6 +9057,7 @@
             "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
             "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^5.2.0"
             },
@@ -8648,6 +9073,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -8659,13 +9085,15 @@
             "version": "5.4.4",
             "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/char-regex": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -8675,6 +9103,7 @@
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
             "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8684,13 +9113,15 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
             "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/chevrotain": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
             "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "regexp-to-ast": "0.5.0"
             }
@@ -8722,6 +9153,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8731,6 +9163,7 @@
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
             "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "consola": "^3.2.3"
             }
@@ -8739,13 +9172,15 @@
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
             "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escape-string-regexp": "^1.0.5"
             },
@@ -8758,6 +9193,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -8767,6 +9203,7 @@
             "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
             "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parent-module": "^2.0.0",
                 "resolve-from": "^5.0.0"
@@ -8783,6 +9220,7 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
             "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "callsites": "^3.1.0"
             },
@@ -8795,6 +9233,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8830,6 +9269,7 @@
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
             "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "slice-ansi": "^7.1.0",
                 "string-width": "^8.0.0"
@@ -8846,6 +9286,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8858,6 +9299,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
             "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-east-asian-width": "^1.3.0",
                 "strip-ansi": "^7.1.0"
@@ -8874,6 +9316,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -8889,6 +9332,7 @@
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
             "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 12"
             }
@@ -8922,6 +9366,7 @@
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -8931,7 +9376,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
             "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -8955,13 +9401,15 @@
             "version": "2.9.3",
             "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
             "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/colorette": {
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/columnify": {
             "version": "1.6.0",
@@ -8994,6 +9442,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -9003,6 +9452,7 @@
             "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.5.1.tgz",
             "integrity": "sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-timsort": "^1.0.3",
                 "core-util-is": "^1.0.3",
@@ -9017,6 +9467,7 @@
             "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
             "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             }
@@ -9033,6 +9484,7 @@
             "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
             "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
@@ -9042,7 +9494,8 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/concat-stream": {
             "version": "2.0.0",
@@ -9052,6 +9505,7 @@
                 "node >= 6.0"
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "inherits": "^2.0.3",
@@ -9083,13 +9537,15 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
             "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/consola": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
             "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.18.0 || >=16.10.0"
             }
@@ -9099,6 +9555,7 @@
             "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.1.1.tgz",
             "integrity": "sha512-rlqa8Lgh8YzT3Akruk05DR79j5gN9NCglHtJZwpi6vxVeaoagz+84UAtKQj/sT+RsfGaZkt3cdFCjcN6yjr5sw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@conventional-changelog/git-client": "^2.5.1",
                 "@types/normalize-package-data": "^2.4.4",
@@ -9121,6 +9578,7 @@
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
             "integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "compare-func": "^2.0.0"
             },
@@ -9146,6 +9604,7 @@
             "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
             "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -9155,6 +9614,7 @@
             "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
             "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "conventional-commits-filter": "^5.0.0",
                 "handlebars": "^4.7.7",
@@ -9173,6 +9633,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -9185,6 +9646,7 @@
             "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
             "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -9194,6 +9656,7 @@
             "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
             "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "meow": "^13.0.0"
             },
@@ -9209,6 +9672,7 @@
             "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-11.2.0.tgz",
             "integrity": "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@conventional-changelog/git-client": "^2.5.1",
                 "conventional-changelog-preset-loader": "^5.0.0",
@@ -9246,7 +9710,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
@@ -9269,6 +9734,7 @@
             "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
             "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
@@ -9297,6 +9763,7 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -9311,6 +9778,7 @@
             "resolved": "https://registry.npmjs.org/cspell/-/cspell-9.6.4.tgz",
             "integrity": "sha512-rZJmgcyBGKX3KcJ3KC9JYVHeKhDEVbmCheSp8eRGMYw6MCG9o7FHqQjGA/u4lEu4A0psr7ACP/5ym/QHyntRbA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-json-reporter": "9.6.4",
                 "@cspell/cspell-performance-monitor": "9.6.4",
@@ -9350,6 +9818,7 @@
             "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-9.6.4.tgz",
             "integrity": "sha512-MecJNR9bIlcPBhyZFsXP6Q2n8qQ2IR9N9HiIz0yh0gBNVydp3LR5JITP5Ji8m7hexmZzVeoXms/dVN74XbS95g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-types": "9.6.4",
                 "comment-json": "^4.5.1",
@@ -9365,6 +9834,7 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
             "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -9380,6 +9850,7 @@
             "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-9.6.4.tgz",
             "integrity": "sha512-Ik9ZQVqV/fJfMt5X6IkC7yHGVH46/qjcqCNWwrMSwvROLM3SemNxxZoLvh0wi0GXz9WF1lHcxLJVdeKUk6QB8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-performance-monitor": "9.6.4",
                 "@cspell/cspell-pipe": "9.6.4",
@@ -9396,6 +9867,7 @@
             "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-9.6.4.tgz",
             "integrity": "sha512-a8asE9BsjJgJ506WUGh5VHrTdVEE8hWELjCJB2atPrW6iY5e4aCIugy0gkRC1ZH9/TseadlmMLrFzHUkJUjzsg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/url": "9.6.4",
                 "cspell-glob": "9.6.4",
@@ -9413,6 +9885,7 @@
             "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-9.6.4.tgz",
             "integrity": "sha512-253VrjbR8QU15h8GtpDQLX5Ti9uNSuNod2T7f8YEElQOb9I/kUXoCj3Cq4P390IC99klqSHIDxHsxd77ex19lA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/url": "9.6.4",
                 "picomatch": "^4.0.3"
@@ -9426,6 +9899,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9438,6 +9912,7 @@
             "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-9.6.4.tgz",
             "integrity": "sha512-rvZyTB45/XSRWx7eAsrvTTAZvBTREr/2G2JWVMdqrptFyq1XReAKHhw/x1HJkNgWC9LKAK3bVQJpjLsNG37U9A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-pipe": "9.6.4",
                 "@cspell/cspell-types": "9.6.4"
@@ -9454,6 +9929,7 @@
             "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-9.6.4.tgz",
             "integrity": "sha512-bmvJ4yn5QK2FZWTkZA4sx2qJqIi8BrUUUV7W209drSwkYjhJtXqP0RyF6Qx4Xuu2D1s0UilEtO5Jd+E9UJkQ6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-service-bus": "9.6.4",
                 "@cspell/url": "9.6.4"
@@ -9467,6 +9943,7 @@
             "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-9.6.4.tgz",
             "integrity": "sha512-fUodKcIHTwvokuowB25XyFzBxlk73yj1QRw2por3BxDz9fAim1zAIohAPAnGuzj3LowYnTMjHLYE7RFDUSxy5A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspell/cspell-bundled-dicts": "9.6.4",
                 "@cspell/cspell-performance-monitor": "9.6.4",
@@ -9502,6 +9979,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9511,6 +9989,7 @@
             "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-9.6.4.tgz",
             "integrity": "sha512-JKwyRtyybbaTrixwI1OgU5Hvva2Z5zHVWl92WBa9U7KijAyiD/Ehp3T3DCYuBwGks7egw7MgWPySkXXnpme6mw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -9523,6 +10002,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9535,6 +10015,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -9547,6 +10028,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
             "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -9556,6 +10038,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -9568,6 +10051,7 @@
             "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
             "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12 || >=16"
             }
@@ -9577,6 +10061,7 @@
             "resolved": "https://registry.npmjs.org/css-tokenize/-/css-tokenize-1.0.1.tgz",
             "integrity": "sha512-gLmmbJdwH9HLY4bcA17lnZ8GgPwEXRbvxBJGHnkiB6gLhRpTzjkjtMIvz7YORGW/Ptv2oMk8b5g+u7mRD6Dd7A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^1.0.33"
@@ -9586,13 +10071,15 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
             "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/css-tokenize/node_modules/readable-stream": {
             "version": "1.1.14",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
             "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -9604,13 +10091,15 @@
             "version": "0.10.31",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/css-tree": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
             "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mdn-data": "2.12.2",
                 "source-map-js": "^1.0.1"
@@ -9623,7 +10112,8 @@
             "version": "2.12.2",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
             "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
@@ -9641,13 +10131,15 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
             "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cssstyle": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssom": "~0.3.6"
             },
@@ -9659,13 +10151,15 @@
             "version": "0.3.8",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dargs": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
             "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9678,6 +10172,7 @@
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -9687,6 +10182,7 @@
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
             "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -9701,6 +10197,7 @@
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
             "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
@@ -9718,6 +10215,7 @@
             "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
             "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
@@ -9735,6 +10233,7 @@
             "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
             "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -9768,13 +10267,15 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
             "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "character-entities": "^2.0.0"
             },
@@ -9788,6 +10289,7 @@
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
             "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -9801,7 +10303,8 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -9817,6 +10320,7 @@
             "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
             "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bundle-name": "^4.1.0",
                 "default-browser-id": "^5.0.0"
@@ -9833,6 +10337,7 @@
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
             "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -9858,6 +10363,7 @@
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -9885,6 +10391,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
@@ -9901,13 +10408,15 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
             "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/degenerator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -9931,6 +10440,7 @@
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -9939,13 +10449,15 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/detect-indent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
             "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12.20"
             },
@@ -9958,6 +10470,7 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
             "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -9988,6 +10501,7 @@
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
             "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dequal": "^2.0.0"
             },
@@ -10011,6 +10525,7 @@
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
             "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -10020,6 +10535,7 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -10032,6 +10548,7 @@
             "resolved": "https://registry.npmjs.org/doiuse/-/doiuse-6.0.6.tgz",
             "integrity": "sha512-XuPRslcWHhQJ+WjCjimRUcNfhZvOiC0610FsY6WeSlzXvoZYtm6iOpR9K0N4wRoM/lP4i7LatT+IhltAzouSOw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "browserslist": "^4.28.1",
                 "caniuse-lite": "^1.0.30001760",
@@ -10055,6 +10572,7 @@
             "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
             "deprecated": "Use your platform's native DOMException instead",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -10067,6 +10585,7 @@
             "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
             "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -10077,6 +10596,7 @@
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
             "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
@@ -10132,6 +10652,7 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
             "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "end-of-stream": "^1.4.1",
                 "inherits": "^2.0.3",
@@ -10165,13 +10686,15 @@
             "version": "0.3.18",
             "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.18.tgz",
             "integrity": "sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/emittery": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
             "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -10212,6 +10735,7 @@
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
             "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -10224,6 +10748,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
             "integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-safe-filename": "^0.1.0"
             },
@@ -10239,6 +10764,7 @@
             "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
             "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -10260,6 +10786,7 @@
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
             "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.2",
                 "arraybuffer.prototype.slice": "^1.0.4",
@@ -10345,7 +10872,8 @@
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/es-html-parser/-/es-html-parser-0.3.1.tgz",
             "integrity": "sha512-YTEasG4xt7FEN4b6qJIPbFo/fzQ5kjRMEQ33QMqSXTvfXqAbC2rHxo32x2/1Rhq7Mlu6wI3MIpM5Kf2VHPXrUQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -10379,6 +10907,7 @@
             "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
             "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hasown": "^2.0.2"
             },
@@ -10391,6 +10920,7 @@
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
             "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-callable": "^1.2.7",
                 "is-date-object": "^1.0.5",
@@ -10450,6 +10980,7 @@
             "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.27.3.tgz",
             "integrity": "sha512-AUXuOxZ145/5Az+lIqk6TdJbxKTyDGkXMJpTExmBdbnHR6n6qAFx+F4oG9ORpVYJ9dQYeQAqzv51TO4DFKsbXw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -10471,6 +11002,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -10483,6 +11015,7 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -10505,6 +11038,7 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10590,6 +11124,7 @@
             "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.1.tgz",
             "integrity": "sha512-1xPtnB7RYRHKrFGll3kRv5gOodHm3/jkk76jrKMZ2yk/G8HU9XoN1I9iHgh1ToAqmGG0/FFrybZMqmqUWp4asA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             },
@@ -10608,6 +11143,7 @@
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
             "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7",
                 "is-core-module": "^2.13.0",
@@ -10619,6 +11155,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -10628,6 +11165,7 @@
             "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
             "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^3.2.7"
             },
@@ -10645,6 +11183,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -10654,6 +11193,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-6.1.0.tgz",
             "integrity": "sha512-xiwHz7mj6+Zj7NWOO/uaWdrQ6zP0zL5CPyKVCNlB4JaoUFeYPYwejf5toqyHGlXzhuPUdCpg31uBRiWqcgiS0A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@mdn/browser-compat-data": "^6.1.1",
                 "ast-metadata-inferer": "^0.8.1",
@@ -10676,6 +11216,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
             "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -10688,6 +11229,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -10756,6 +11298,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -10789,6 +11332,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
             "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.1.1"
             }
@@ -10798,6 +11342,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -10835,11 +11380,29 @@
                 }
             }
         },
+        "node_modules/eslint-plugin-oxlint": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.43.0.tgz",
+            "integrity": "sha512-SUP8AFLe1D6/jcGenpDu3DrPkDfqbBzoDZqSN0SHAo7CygqAHaltIhBay6y9Lt2Iib7TW7sNPHC22MXmE2XlGw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "jsonc-parser": "^3.3.1"
+            }
+        },
+        "node_modules/eslint-plugin-oxlint/node_modules/jsonc-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/eslint-plugin-package-json": {
             "version": "0.88.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.88.2.tgz",
             "integrity": "sha512-KCpzuc0sI/7Kzt+QBsSbq+e8ClpoiTuoID7D2WxQe2r3XB+2SSPkqqr9M9oLfUjQDsn3oROAnb5lP2yh+oBfVg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@altano/repository-tools": "^2.0.1",
                 "change-case": "^5.4.4",
@@ -10865,6 +11428,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -10894,6 +11458,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.5.1.tgz",
             "integrity": "sha512-q7oqVQTTfa3VXJQ8E+ln0QttPGrs/XmSO1FjOMzQYBMYF3btih4FIrhEYh34JF184GYDmq3lJ/n7CMa49OHBvA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "globals": "^16.4.0"
             },
@@ -10909,6 +11474,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
             "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -11003,6 +11569,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.6.tgz",
             "integrity": "sha512-3mVUqsAUSylGfkJMj2v0aC2Cu/eUunDLm+XMjLf0uLjAZao205NWF3g6EXxcCAFO+rCZiQ6Or1WQkUcU9/sKFQ==",
             "license": "LGPL-3.0-only",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "4.12.2",
                 "builtin-modules": "3.3.0",
@@ -11024,6 +11591,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -11036,6 +11604,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-62.0.0.tgz",
             "integrity": "sha512-HIlIkGLkvf29YEiS/ImuDZQbP12gWyx5i3C6XrRxMvVdqMroCI9qoVYCoIl17ChN+U89pn9sVwLxhIWj5nEc7g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "@eslint-community/eslint-utils": "^4.9.0",
@@ -11071,6 +11640,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
             "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -11083,6 +11653,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -11111,6 +11682,7 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.0.tgz",
             "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
                 "@types/estree": "^1.0.8",
@@ -11141,6 +11713,7 @@
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
             "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -11153,6 +11726,7 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
             "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -11169,6 +11743,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -11181,6 +11756,7 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
             "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
@@ -11211,6 +11787,7 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -11223,6 +11800,7 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -11235,6 +11813,7 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -11260,6 +11839,7 @@
             "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
             "integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -11271,13 +11851,15 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -11300,6 +11882,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
             "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -11309,6 +11892,7 @@
             "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
             "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "^29.7.0",
                 "jest-get-type": "^29.6.3",
@@ -11324,7 +11908,8 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
             "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-content-type-parse": {
             "version": "3.0.0",
@@ -11340,7 +11925,8 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -11352,13 +11938,15 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
             "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/fast-equals": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
             "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -11368,6 +11956,7 @@
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -11384,6 +11973,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -11401,7 +11991,8 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-uri": {
             "version": "3.1.0",
@@ -11417,13 +12008,15 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ],
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
             "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
             "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4.9.1"
             }
@@ -11433,6 +12026,7 @@
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
             "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -11442,6 +12036,7 @@
             "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
             "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "format": "^0.2.0"
             },
@@ -11455,6 +12050,7 @@
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
             "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "bser": "2.1.1"
             }
@@ -11464,6 +12060,7 @@
             "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
             "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "walk-up-path": "^4.0.0"
             }
@@ -11516,6 +12113,7 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -11561,6 +12159,7 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -11591,6 +12190,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -11607,6 +12207,7 @@
             "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
             "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -11629,6 +12230,7 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -11641,7 +12243,8 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/follow-redirects": {
             "version": "1.15.11",
@@ -11669,6 +12272,7 @@
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
             "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-callable": "^1.2.7"
             },
@@ -11699,6 +12303,7 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
             "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.x"
             }
@@ -11806,6 +12411,7 @@
             "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
             "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -11825,13 +12431,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -11841,6 +12449,7 @@
             "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
             "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -11860,6 +12469,7 @@
             "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-8.0.8.tgz",
             "integrity": "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -11887,6 +12497,7 @@
             "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
             "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -11923,6 +12534,7 @@
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -11945,6 +12557,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -11957,6 +12570,7 @@
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
             "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
@@ -11974,6 +12588,7 @@
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
             "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
@@ -11988,6 +12603,7 @@
             "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
             "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "citty": "^0.1.6",
                 "consola": "^3.4.0",
@@ -12005,6 +12621,7 @@
             "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.2.1.tgz",
             "integrity": "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
@@ -12014,6 +12631,7 @@
             "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
             "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dargs": "^8.0.0",
                 "meow": "^12.0.1",
@@ -12031,6 +12649,7 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
             "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.10"
             },
@@ -12043,6 +12662,7 @@
             "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
             "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-ssh": "^1.4.0",
                 "parse-url": "^9.2.0"
@@ -12053,6 +12673,7 @@
             "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
             "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "git-up": "^8.1.0"
             }
@@ -12061,7 +12682,8 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/glob": {
             "version": "8.1.0",
@@ -12089,6 +12711,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -12124,6 +12747,7 @@
             "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
             "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ini": "4.1.1"
             },
@@ -12139,6 +12763,7 @@
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
             "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "global-prefix": "^3.0.0"
             },
@@ -12151,6 +12776,7 @@
             "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
             "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ini": "^1.3.5",
                 "kind-of": "^6.0.2",
@@ -12164,13 +12790,15 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/global-prefix/node_modules/which": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -12196,6 +12824,7 @@
             "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
             "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "define-properties": "^1.2.1",
                 "gopd": "^1.0.1"
@@ -12212,6 +12841,7 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.0.tgz",
             "integrity": "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sindresorhus/merge-streams": "^4.0.0",
                 "fast-glob": "^3.3.3",
@@ -12232,6 +12862,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -12241,6 +12872,7 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
             "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=14.16"
             },
@@ -12252,7 +12884,8 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
             "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/gopd": {
             "version": "1.2.0",
@@ -12277,6 +12910,7 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
             "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.2",
@@ -12298,6 +12932,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12307,6 +12942,7 @@
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
             "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -12328,6 +12964,7 @@
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -12340,6 +12977,7 @@
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
             "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dunder-proto": "^1.0.0"
             },
@@ -12382,6 +13020,7 @@
             "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
             "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hookified": "^1.14.0"
             },
@@ -12405,13 +13044,15 @@
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
             "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/hosted-git-info": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
             "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
@@ -12423,13 +13064,15 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/html-encoding-sniffer": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
             "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -12441,13 +13084,15 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/html-tags": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
             "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.10"
             },
@@ -12460,6 +13105,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -12474,6 +13120,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -12487,6 +13134,7 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -12496,6 +13144,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -12555,6 +13204,7 @@
             "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
             "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "import-from": "^3.0.0"
             },
@@ -12583,6 +13233,7 @@
             "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
             "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -12595,6 +13246,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -12604,6 +13256,7 @@
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
             "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -12623,6 +13276,7 @@
             "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
             "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -12633,6 +13287,7 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -12642,6 +13297,7 @@
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
             "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12671,6 +13327,7 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
             "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -12680,6 +13337,7 @@
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
             "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/ansi": "^1.0.2",
                 "@inquirer/core": "^10.3.2",
@@ -12706,6 +13364,7 @@
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
             "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "hasown": "^2.0.2",
@@ -12720,6 +13379,7 @@
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
             "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 12"
             }
@@ -12729,6 +13389,7 @@
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
             "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -12752,6 +13413,7 @@
             "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
             "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "async-function": "^1.0.0",
                 "call-bound": "^1.0.3",
@@ -12771,6 +13433,7 @@
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
             "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-bigints": "^1.0.2"
             },
@@ -12786,6 +13449,7 @@
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
             "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
@@ -12802,6 +13466,7 @@
             "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
             "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "builtin-modules": "^5.0.0"
             },
@@ -12817,6 +13482,7 @@
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
             "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.20"
             },
@@ -12829,6 +13495,7 @@
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -12856,6 +13523,7 @@
             "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
             "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "get-intrinsic": "^1.2.6",
@@ -12873,6 +13541,7 @@
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
             "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "has-tostringtag": "^1.0.2"
@@ -12905,6 +13574,7 @@
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12914,6 +13584,7 @@
             "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
             "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3"
             },
@@ -12938,6 +13609,7 @@
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -12947,6 +13619,7 @@
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
             "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.4",
                 "generator-function": "^2.0.0",
@@ -12966,6 +13639,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -12978,6 +13652,7 @@
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -12996,6 +13671,7 @@
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -13011,6 +13687,7 @@
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
             "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -13023,6 +13700,7 @@
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -13042,6 +13720,7 @@
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
             "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -13054,6 +13733,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -13063,6 +13743,7 @@
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
             "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
@@ -13079,6 +13760,7 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
             "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13088,6 +13770,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
             "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -13100,6 +13783,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
             "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -13112,6 +13796,7 @@
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13120,7 +13805,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-reference": {
             "version": "1.2.1",
@@ -13137,6 +13823,7 @@
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
             "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "gopd": "^1.2.0",
@@ -13155,6 +13842,7 @@
             "resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
             "integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -13167,6 +13855,7 @@
             "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
             "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -13179,6 +13868,7 @@
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
             "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3"
             },
@@ -13194,6 +13884,7 @@
             "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
             "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "protocols": "^2.0.1"
             }
@@ -13203,6 +13894,7 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -13215,6 +13907,7 @@
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
             "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
@@ -13231,6 +13924,7 @@
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
             "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "has-symbols": "^1.1.0",
@@ -13248,6 +13942,7 @@
             "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
             "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "which-typed-array": "^1.1.16"
             },
@@ -13263,6 +13958,7 @@
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
             "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -13275,6 +13971,7 @@
             "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
             "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -13287,6 +13984,7 @@
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
             "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3"
             },
@@ -13302,6 +14000,7 @@
             "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
             "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "get-intrinsic": "^1.2.6"
@@ -13330,19 +14029,22 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/issue-parser": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
             "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lodash.capitalize": "^4.2.1",
                 "lodash.escaperegexp": "^4.1.2",
@@ -13359,6 +14061,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
             "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13368,6 +14071,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
             "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -13384,6 +14088,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -13396,6 +14101,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
             "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -13410,6 +14116,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
             "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -13425,6 +14132,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -13437,6 +14145,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
             "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.1.1",
                 "istanbul-lib-coverage": "^3.0.0",
@@ -13451,6 +14160,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13460,6 +14170,7 @@
             "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
             "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -13518,6 +14229,7 @@
             "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
             "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "execa": "^5.0.0",
                 "jest-util": "^29.7.0",
@@ -13532,6 +14244,7 @@
             "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
             "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -13563,6 +14276,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -13574,13 +14288,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-circus/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -13593,6 +14309,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -13607,6 +14324,7 @@
             "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
             "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/test-result": "^29.7.0",
@@ -13640,6 +14358,7 @@
             "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
             "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/test-sequencer": "^29.7.0",
@@ -13685,6 +14404,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -13696,13 +14416,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-config/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -13721,6 +14443,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13731,6 +14454,7 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -13751,6 +14475,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -13763,6 +14488,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -13793,6 +14519,7 @@
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
             "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "detect-newline": "^3.0.0"
             },
@@ -13805,6 +14532,7 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13814,6 +14542,7 @@
             "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
             "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "chalk": "^4.0.0",
@@ -13830,6 +14559,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -13841,13 +14571,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-each/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -13860,6 +14592,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -13902,6 +14635,7 @@
             "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
             "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -13919,6 +14653,7 @@
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
             "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -13928,6 +14663,7 @@
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
             "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/graceful-fs": "^4.1.3",
@@ -13953,6 +14689,7 @@
             "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
             "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jest-get-type": "^29.6.3",
                 "pretty-format": "^29.7.0"
@@ -13966,6 +14703,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -13977,13 +14715,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-leak-detector/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -13996,6 +14736,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14010,6 +14751,7 @@
             "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
             "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "jest-diff": "^29.7.0",
@@ -14025,6 +14767,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -14036,13 +14779,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14055,6 +14800,7 @@
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
             "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.6.3",
@@ -14070,6 +14816,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14084,6 +14831,7 @@
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
             "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@jest/types": "^29.6.3",
@@ -14104,6 +14852,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -14115,13 +14864,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-message-util/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14134,6 +14885,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14148,6 +14900,7 @@
             "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
             "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -14162,6 +14915,7 @@
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
             "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -14179,6 +14933,7 @@
             "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-14.6.2.tgz",
             "integrity": "sha512-QWnjfXrnYJX65D+iZXBrdQ0ABHSo6DGvcmL3dGYOdF+V2ZhDlqJwKTmt7nyiOcORPdCL+20P8y+Q1mmnjZTHKQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "esbuild-wasm": ">=0.15.13",
@@ -14212,6 +14967,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -14223,13 +14979,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-preset-angular/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14242,6 +15000,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14256,6 +15015,7 @@
             "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
             "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -14265,6 +15025,7 @@
             "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
             "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
@@ -14285,6 +15046,7 @@
             "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
             "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jest-regex-util": "^29.6.3",
                 "jest-snapshot": "^29.7.0"
@@ -14298,6 +15060,7 @@
             "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
             "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "^29.7.0",
                 "@jest/environment": "^29.7.0",
@@ -14330,6 +15093,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14339,6 +15103,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
             "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -14349,6 +15114,7 @@
             "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
             "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -14383,6 +15149,7 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -14403,6 +15170,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -14415,6 +15183,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14424,6 +15193,7 @@
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
             "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@babel/generator": "^7.7.2",
@@ -14455,6 +15225,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -14466,13 +15237,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-snapshot/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14485,6 +15258,7 @@
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
             "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.6.3",
@@ -14500,6 +15274,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14514,6 +15289,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -14526,6 +15302,7 @@
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
             "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -14549,6 +15326,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14558,6 +15336,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -14570,6 +15349,7 @@
             "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
             "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "camelcase": "^6.2.0",
@@ -14587,6 +15367,7 @@
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -14598,13 +15379,15 @@
             "version": "0.27.10",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
             "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-validate/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14617,6 +15400,7 @@
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14629,6 +15413,7 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -14643,6 +15428,7 @@
             "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
             "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/test-result": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -14662,6 +15448,7 @@
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
             "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "jest-util": "^29.7.0",
@@ -14677,6 +15464,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -14692,6 +15480,7 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -14707,6 +15496,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
             "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -14719,6 +15509,7 @@
             "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
             "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.0.0"
             }
@@ -14728,6 +15519,7 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
             "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "acorn": "^8.8.1",
@@ -14784,7 +15576,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -14821,6 +15614,7 @@
             "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
             "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.5.0",
                 "eslint-visitor-keys": "^3.0.0",
@@ -14839,6 +15633,7 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -14851,6 +15646,7 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -14868,6 +15664,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -14899,6 +15696,7 @@
             "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
             "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
@@ -14908,6 +15706,7 @@
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -14917,6 +15716,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14926,6 +15726,7 @@
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14934,13 +15735,15 @@
             "version": "0.37.0",
             "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
             "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14950,6 +15753,7 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -14973,6 +15777,7 @@
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
             "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "commander": "^14.0.2",
                 "listr2": "^9.0.5",
@@ -14997,6 +15802,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
             "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -15006,6 +15812,7 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
             "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -15021,6 +15828,7 @@
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
             "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.0.0",
                 "colorette": "^2.0.20",
@@ -15038,6 +15846,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15050,6 +15859,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15061,13 +15871,15 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/listr2/node_modules/string-width": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -15085,6 +15897,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -15100,6 +15913,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
             "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.2.1",
                 "string-width": "^7.0.0",
@@ -15127,6 +15941,7 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -15141,7 +15956,8 @@
             "version": "4.17.23",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
             "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -15153,7 +15969,8 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
             "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -15166,31 +15983,36 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
             "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.kebabcase": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
             "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -15202,43 +16024,50 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
             "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.snakecase": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
             "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.startcase": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
             "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
             "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.upperfirst": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
             "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/log-symbols": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
             "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^5.3.0",
                 "is-unicode-supported": "^1.3.0"
@@ -15255,6 +16084,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -15267,6 +16097,7 @@
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
             "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15279,6 +16110,7 @@
             "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
             "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-escapes": "^7.0.0",
                 "cli-cursor": "^5.0.0",
@@ -15298,6 +16130,7 @@
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
             "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "environment": "^1.0.0"
             },
@@ -15313,6 +16146,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15325,6 +16159,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15337,6 +16172,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
             "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "restore-cursor": "^5.0.0"
             },
@@ -15351,13 +16187,15 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/log-update/node_modules/onetime": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
             "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mimic-function": "^5.0.0"
             },
@@ -15373,6 +16211,7 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
             "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "onetime": "^7.0.0",
                 "signal-exit": "^4.1.0"
@@ -15389,6 +16228,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -15401,6 +16241,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -15418,6 +16259,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -15433,6 +16275,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
             "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.2.1",
                 "string-width": "^7.0.0",
@@ -15450,6 +16293,7 @@
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
             "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -15460,6 +16304,7 @@
             "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
             "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.0.3"
             }
@@ -15478,6 +16323,7 @@
             "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.4.0.tgz",
             "integrity": "sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -15522,6 +16368,7 @@
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
             "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "tmpl": "1.0.5"
             }
@@ -15531,6 +16378,7 @@
             "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
             "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -15550,6 +16398,7 @@
             "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
             "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -15560,6 +16409,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
             "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "escape-string-regexp": "^5.0.0",
@@ -15576,6 +16426,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
             "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15588,6 +16439,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
             "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "@types/unist": "^3.0.0",
@@ -15612,6 +16464,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
             "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -15630,6 +16483,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
             "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15642,6 +16496,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
             "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mdast-util-from-markdown": "^2.0.0",
                 "mdast-util-gfm-autolink-literal": "^2.0.0",
@@ -15661,6 +16516,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
             "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "ccount": "^2.0.0",
@@ -15678,6 +16534,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
             "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.1.0",
@@ -15695,6 +16552,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
             "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "mdast-util-from-markdown": "^2.0.0",
@@ -15710,6 +16568,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
             "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -15727,6 +16586,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
             "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "devlop": "^1.0.0",
@@ -15743,6 +16603,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
             "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "unist-util-is": "^6.0.0"
@@ -15757,6 +16618,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
             "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0",
                 "@types/unist": "^3.0.0",
@@ -15778,6 +16640,7 @@
             "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
             "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/mdast": "^4.0.0"
             },
@@ -15790,13 +16653,15 @@
             "version": "2.23.0",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.23.0.tgz",
             "integrity": "sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/meow": {
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
             "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -15808,13 +16673,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -15834,6 +16701,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/debug": "^4.0.0",
                 "debug": "^4.0.0",
@@ -15869,6 +16737,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "decode-named-character-reference": "^1.0.0",
                 "devlop": "^1.0.0",
@@ -15893,6 +16762,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
             "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fault": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -15909,6 +16779,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
             "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-extension-gfm-autolink-literal": "^2.0.0",
                 "micromark-extension-gfm-footnote": "^2.0.0",
@@ -15929,6 +16800,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
             "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-sanitize-uri": "^2.0.0",
@@ -15945,6 +16817,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
             "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-core-commonmark": "^2.0.0",
@@ -15965,6 +16838,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
             "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-chunked": "^2.0.0",
@@ -15983,6 +16857,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
             "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -16000,6 +16875,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
             "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-types": "^2.0.0"
             },
@@ -16013,6 +16889,7 @@
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
             "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-factory-space": "^2.0.0",
@@ -16040,6 +16917,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
@@ -16061,6 +16939,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -16083,6 +16962,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
@@ -16103,6 +16983,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-factory-space": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -16125,6 +17006,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-factory-space": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -16147,6 +17029,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
@@ -16167,6 +17050,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0"
             }
@@ -16186,6 +17070,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
@@ -16207,6 +17092,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-chunked": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
@@ -16227,6 +17113,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0"
             }
@@ -16246,6 +17133,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "decode-named-character-reference": "^1.0.0",
                 "micromark-util-character": "^2.0.0",
@@ -16267,7 +17155,8 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/micromark-util-html-tag-name": {
             "version": "2.0.1",
@@ -16283,7 +17172,8 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/micromark-util-normalize-identifier": {
             "version": "2.0.1",
@@ -16300,6 +17190,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-symbol": "^2.0.0"
             }
@@ -16319,6 +17210,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-types": "^2.0.0"
             }
@@ -16338,6 +17230,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-encode": "^2.0.0",
@@ -16359,6 +17252,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "devlop": "^1.0.0",
                 "micromark-util-chunked": "^2.0.0",
@@ -16380,7 +17274,8 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/micromark-util-types": {
             "version": "2.0.2",
@@ -16396,13 +17291,15 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -16416,6 +17313,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -16458,6 +17356,7 @@
             "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
             "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -16519,6 +17418,7 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
             "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/minimatch": "^3.0.3",
                 "array-differ": "^3.0.0",
@@ -16537,13 +17437,15 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/multimatch/node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -16556,6 +17458,7 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
             "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
             }
@@ -16565,6 +17468,7 @@
             "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
             "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.17"
             },
@@ -16595,6 +17499,7 @@
             "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
             "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "picocolors": "^1.1.1"
             }
@@ -16603,13 +17508,15 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/natural-orderby": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
             "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -16618,13 +17525,15 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/netmask": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -16634,6 +17543,7 @@
             "resolved": "https://registry.npmjs.org/new-github-release-url/-/new-github-release-url-2.0.0.tgz",
             "integrity": "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^2.5.1"
             },
@@ -16649,6 +17559,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=12.20"
             },
@@ -16661,6 +17572,7 @@
             "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
             "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
@@ -16671,6 +17583,7 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -16690,25 +17603,29 @@
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
             "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-fetch/node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-fetch/node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/node-fetch/node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -16718,7 +17635,8 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-machine-id": {
             "version": "1.1.12",
@@ -16738,6 +17656,7 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
             "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "hosted-git-info": "^8.0.0",
                 "semver": "^7.3.5",
@@ -16752,6 +17671,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -16764,6 +17684,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16784,7 +17705,8 @@
             "version": "2.2.23",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/nx": {
             "version": "22.4.5",
@@ -16793,7 +17715,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "0.2.4",
                 "@yarnpkg/lockfile": "^1.1.0",
@@ -16982,6 +17903,7 @@
             "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
             "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "citty": "^0.2.0",
                 "pathe": "^2.0.3",
@@ -16998,13 +17920,15 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
             "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -17017,6 +17941,7 @@
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -17026,6 +17951,7 @@
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -17046,6 +17972,7 @@
             "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
             "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -17064,6 +17991,7 @@
             "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
             "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -17078,6 +18006,7 @@
             "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
             "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -17095,7 +18024,8 @@
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -17144,6 +18074,7 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -17161,6 +18092,7 @@
             "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
             "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^5.3.0",
                 "cli-cursor": "^5.0.0",
@@ -17184,6 +18116,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -17196,6 +18129,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -17208,6 +18142,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
             "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "restore-cursor": "^5.0.0"
             },
@@ -17223,6 +18158,7 @@
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
             "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -17234,13 +18170,15 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/ora/node_modules/onetime": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
             "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mimic-function": "^5.0.0"
             },
@@ -17256,6 +18194,7 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
             "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "onetime": "^7.0.0",
                 "signal-exit": "^4.1.0"
@@ -17272,6 +18211,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -17284,6 +18224,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -17301,6 +18242,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -17316,6 +18258,7 @@
             "resolved": "https://registry.npmjs.org/os-name/-/os-name-6.1.0.tgz",
             "integrity": "sha512-zBd1G8HkewNd2A8oQ8c6BN/f/c9EId7rSUueOLGu28govmUctXmM+3765GwsByv9nYUdrLqHphXlYIc86saYsg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "macos-release": "^3.3.0",
                 "windows-release": "^6.1.0"
@@ -17332,6 +18275,7 @@
             "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
             "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-intrinsic": "^1.2.6",
                 "object-keys": "^1.1.1",
@@ -17344,11 +18288,46 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/oxlint": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.43.0.tgz",
+            "integrity": "sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==",
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "oxlint": "bin/oxlint"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxlint/darwin-arm64": "1.43.0",
+                "@oxlint/darwin-x64": "1.43.0",
+                "@oxlint/linux-arm64-gnu": "1.43.0",
+                "@oxlint/linux-arm64-musl": "1.43.0",
+                "@oxlint/linux-x64-gnu": "1.43.0",
+                "@oxlint/linux-x64-musl": "1.43.0",
+                "@oxlint/win32-arm64": "1.43.0",
+                "@oxlint/win32-x64": "1.43.0"
+            },
+            "peerDependencies": {
+                "oxlint-tsgolint": ">=0.11.2"
+            },
+            "peerDependenciesMeta": {
+                "oxlint-tsgolint": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -17364,6 +18343,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -17388,6 +18368,7 @@
             "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
             "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.1.2",
@@ -17407,6 +18388,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -17416,6 +18398,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -17429,6 +18412,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -17442,6 +18426,7 @@
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -17455,6 +18440,7 @@
             "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.60.0.tgz",
             "integrity": "sha512-3BBkeFHm3O1VsazTSIN8+AGAl/eJQvTvWquECchRszIW6SC3aJ/fZHwZkpsmJlt7FMjTMNEgz+EhamVn94wgFw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "semver": "^7.7.2",
                 "validate-npm-package-license": "^3.0.4",
@@ -17473,6 +18459,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -17485,6 +18472,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -17497,6 +18485,7 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
             "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "string-width": "^7.2.0",
                 "strip-ansi": "^7.1.0",
@@ -17510,13 +18499,15 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/package-json-validator/node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -17529,6 +18520,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
             "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "emoji-regex": "^10.3.0",
                 "get-east-asian-width": "^1.0.0",
@@ -17546,6 +18538,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -17561,6 +18554,7 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
             "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.2.1",
                 "string-width": "^7.0.0",
@@ -17578,6 +18572,7 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
             "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
@@ -17595,6 +18590,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
             "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
@@ -17616,6 +18612,7 @@
             "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
             "integrity": "sha512-yx5DfvkN8JsHL2xk2Os9oTia467qnvRgey4ahSm2X8epehBLx/gWLcy5KI+Y36ful5DzGbCS6RazqZGgy1gHNw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "author-regex": "^1.0.0"
             },
@@ -17628,6 +18625,7 @@
             "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.3.tgz",
             "integrity": "sha512-tfalY5/4SqGaV/GIGzWyHnFjlpTPTNpENR9Ea2lLldSJ8EWXMsvacWucqY3m3I4YPtas15IxTLQVQ5NSYXPrww==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "parse-github-url": "cli.js"
             },
@@ -17664,6 +18662,7 @@
             "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
             "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "protocols": "^2.0.0"
             }
@@ -17673,6 +18672,7 @@
             "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
             "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-path": "^7.0.0",
                 "parse-path": "^7.0.0"
@@ -17686,6 +18686,7 @@
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
             "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "entities": "^6.0.0"
             },
@@ -17707,6 +18708,7 @@
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -17764,13 +18766,15 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/perfect-debounce": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
             "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -17784,7 +18788,6 @@
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -17797,6 +18800,7 @@
             "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
             "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "pidtree": "bin/pidtree.js"
             },
@@ -17809,6 +18813,7 @@
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
             "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -17882,6 +18887,7 @@
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "confbox": "^0.2.2",
                 "exsolve": "^1.0.7",
@@ -17893,6 +18899,7 @@
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
             "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -17902,6 +18909,7 @@
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
             "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -17925,7 +18933,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -18050,6 +19057,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0"
             },
@@ -18062,7 +19070,6 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
             "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -18076,6 +19083,7 @@
             "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-9.1.0.tgz",
             "integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "postcss": "^8.4.20"
             }
@@ -18091,6 +19099,7 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -18116,6 +19125,7 @@
             "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
             "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-diff": "^1.1.2"
             },
@@ -18128,6 +19138,7 @@
             "resolved": "https://registry.npmjs.org/prettier-package-json/-/prettier-package-json-2.8.0.tgz",
             "integrity": "sha512-WxtodH/wWavfw3MR7yK/GrS4pASEQ+iSTkdtSxPJWvqzG55ir5nvbLt9rw5AOiEcqqPCRM92WCtR1rk3TG3JSQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-author": "^2.0.0",
                 "commander": "^4.0.1",
@@ -18148,6 +19159,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -18158,6 +19170,7 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -18178,6 +19191,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -18189,7 +19203,8 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
             "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/prettier-plugin-organize-attributes": {
             "version": "1.0.0",
@@ -18237,6 +19252,7 @@
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
             "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.5"
@@ -18249,13 +19265,15 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
             "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/proxy-agent": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
             "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -18275,6 +19293,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -18284,6 +19303,7 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -18297,6 +19317,7 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "4"
@@ -18310,6 +19331,7 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -18325,6 +19347,7 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -18355,13 +19378,15 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/qified": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
             "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hookified": "^1.14.0"
             },
@@ -18373,7 +19398,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -18393,13 +19419,15 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/rc9": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
             "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "defu": "^6.1.4",
                 "destr": "^2.0.3"
@@ -18430,6 +19458,7 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
             "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14.18.0"
             },
@@ -18443,6 +19472,7 @@
             "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
             "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.8.0"
             },
@@ -18454,13 +19484,15 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
             "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -18503,6 +19535,7 @@
             "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
             "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.8.0",
                 "refa": "^0.12.1"
@@ -18515,13 +19548,15 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
             "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/regexp-tree": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
             "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "regexp-tree": "bin/regexp-tree"
             }
@@ -18531,6 +19566,7 @@
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
             "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
@@ -18636,6 +19672,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -18648,6 +19685,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
             "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -18660,6 +19698,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
             "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "restore-cursor": "^5.0.0"
             },
@@ -18675,6 +19714,7 @@
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
             "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.20"
             },
@@ -18687,6 +19727,7 @@
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -18699,6 +19740,7 @@
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
             "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-unicode-supported": "^2.0.0",
                 "yoctocolors": "^2.1.1"
@@ -18715,6 +19757,7 @@
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -18724,6 +19767,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
             "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mime-db": "^1.54.0"
             },
@@ -18740,6 +19784,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
             "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mimic-function": "^5.0.0"
             },
@@ -18755,6 +19800,7 @@
             "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
             "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
@@ -18773,6 +19819,7 @@
             "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
             "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^5.6.2",
                 "cli-cursor": "^5.0.0",
@@ -18796,6 +19843,7 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
             "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "onetime": "^7.0.0",
                 "signal-exit": "^4.1.0"
@@ -18812,6 +19860,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -18824,6 +19873,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -18836,6 +19886,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
             "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-east-asian-width": "^1.3.0",
                 "strip-ansi": "^7.1.0"
@@ -18852,6 +19903,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -18876,6 +19928,7 @@
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18884,7 +19937,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/resize-observer-polyfill": {
             "version": "1.5.1",
@@ -18918,6 +19972,7 @@
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -18930,6 +19985,7 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -18971,6 +20027,7 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -18980,6 +20037,7 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
             "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -18989,7 +20047,8 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
             "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/rollup": {
             "version": "4.57.1",
@@ -18997,7 +20056,6 @@
             "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -19100,6 +20158,7 @@
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
             "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -19112,6 +20171,7 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
             "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -19135,6 +20195,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
@@ -19154,6 +20215,7 @@
             "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
             "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.2",
@@ -19193,6 +20255,7 @@
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
             "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "isarray": "^2.0.5"
@@ -19209,6 +20272,7 @@
             "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
             "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -19225,13 +20289,15 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -19244,6 +20310,7 @@
             "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
             "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.8.0",
                 "refa": "^0.12.0",
@@ -19267,6 +20334,7 @@
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -19284,6 +20352,7 @@
             "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -19299,6 +20368,7 @@
             "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
             "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -19313,6 +20383,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -19325,6 +20396,7 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -19334,6 +20406,7 @@
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -19353,6 +20426,7 @@
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3"
@@ -19369,6 +20443,7 @@
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -19387,6 +20462,7 @@
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -19411,13 +20487,15 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -19427,6 +20505,7 @@
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
             "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.2.1",
                 "is-fullwidth-code-point": "^5.0.0"
@@ -19443,6 +20522,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -19455,6 +20535,7 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
             "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-east-asian-width": "^1.3.1"
             },
@@ -19470,6 +20551,7 @@
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
@@ -19480,6 +20562,7 @@
             "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
             "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             },
@@ -19492,6 +20575,7 @@
             "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
             "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dot-case": "^3.0.4",
                 "tslib": "^2.0.3"
@@ -19502,6 +20586,7 @@
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
@@ -19516,6 +20601,7 @@
             "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
             "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
@@ -19530,6 +20616,7 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -19538,19 +20625,22 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
             "integrity": "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/sort-order": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/sort-order/-/sort-order-1.1.2.tgz",
             "integrity": "sha512-Q8tOrwB1TSv9fNUXym9st3TZJODtmcOIi2JWCkVNQPrRg17KPwlpwweTEb7pMwUIFMTAgx2/JsQQXEPFzYQj3A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/sort-package-json": {
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.6.1.tgz",
             "integrity": "sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "detect-indent": "^7.0.2",
                 "detect-newline": "^4.0.1",
@@ -19572,6 +20662,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -19584,6 +20675,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
             "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">= 12"
             }
@@ -19623,6 +20715,7 @@
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
             "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -19632,13 +20725,15 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
             "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-            "license": "CC-BY-3.0"
+            "license": "CC-BY-3.0",
+            "peer": true
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -19648,13 +20743,15 @@
             "version": "3.0.22",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
             "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
-            "license": "CC0-1.0"
+            "license": "CC0-1.0",
+            "peer": true
         },
         "node_modules/split2": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
             "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 10.x"
             }
@@ -19670,6 +20767,7 @@
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
             "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -19682,6 +20780,7 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
             "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -19691,6 +20790,7 @@
             "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
             "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -19703,6 +20803,7 @@
             "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
             "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "internal-slot": "^1.1.0"
@@ -19715,7 +20816,8 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
             "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
@@ -19731,6 +20833,7 @@
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
             "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.6.19"
             }
@@ -19747,6 +20850,7 @@
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
             "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -19774,6 +20878,7 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
             "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.2",
@@ -19795,6 +20900,7 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
             "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.2",
@@ -19813,6 +20919,7 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
             "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -19851,6 +20958,7 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -19860,6 +20968,7 @@
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
             "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -19872,6 +20981,7 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -19883,7 +20993,8 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
             "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/stylelint": {
             "version": "17.1.1",
@@ -19963,6 +21074,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -20111,6 +21223,7 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -20123,6 +21236,7 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
             "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 16"
             }
@@ -20132,6 +21246,7 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -20158,6 +21273,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -20167,6 +21283,7 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
             "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^6.1.20"
             }
@@ -20176,6 +21293,7 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
             "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cacheable": "^2.3.2",
                 "flatted": "^3.3.3",
@@ -20187,6 +21305,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
             "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -20196,6 +21315,7 @@
             "resolved": "https://registry.npmjs.org/meow/-/meow-14.0.0.tgz",
             "integrity": "sha512-JhC3R1f6dbspVtmF3vKjAWz1EVIvwFrGGPLSdU6rK79xBwHWTuHoLnRX/t1/zHS1Ch1Y2UtIrih7DAHuH9JFJA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -20208,6 +21328,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -20220,6 +21341,7 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
             "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "get-east-asian-width": "^1.3.0",
                 "strip-ansi": "^7.1.0"
@@ -20236,6 +21358,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -20251,6 +21374,7 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.0.tgz",
             "integrity": "sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
@@ -20276,6 +21400,7 @@
             "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
             "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^5.0.1",
                 "supports-color": "^10.2.2"
@@ -20292,6 +21417,7 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
             "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -20304,6 +21430,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
             "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -20326,19 +21453,22 @@
         "node_modules/svg-tags": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-            "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
+            "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+            "peer": true
         },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/synckit": {
             "version": "0.11.12",
             "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
             "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@pkgr/core": "^0.2.9"
             },
@@ -20354,6 +21484,7 @@
             "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
             "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.1",
                 "lodash.truncate": "^4.4.2",
@@ -20370,6 +21501,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -20385,13 +21517,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/table/node_modules/slice-ansi": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
             "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "astral-regex": "^2.0.0",
@@ -20426,6 +21560,7 @@
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
             "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -20441,6 +21576,7 @@
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -20461,6 +21597,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -20473,6 +21610,7 @@
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
             "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -20519,13 +21657,15 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -20538,6 +21678,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
             "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -20553,6 +21694,7 @@
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -20562,6 +21704,7 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
             "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.1"
             },
@@ -20596,6 +21739,7 @@
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
             "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bs-logger": "^0.2.6",
                 "fast-json-stable-stringify": "^2.1.0",
@@ -20648,6 +21792,7 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -20660,6 +21805,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -20673,7 +21819,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -20717,6 +21862,7 @@
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
             "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/json5": "^0.0.29",
                 "json5": "^1.0.2",
@@ -20729,6 +21875,7 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
             "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.0"
             },
@@ -20747,6 +21894,7 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -20759,6 +21907,7 @@
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -20768,6 +21917,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -20780,6 +21930,7 @@
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
@@ -20794,6 +21945,7 @@
             "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
             "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "for-each": "^0.3.3",
@@ -20813,6 +21965,7 @@
             "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
             "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
                 "call-bind": "^1.0.8",
@@ -20834,6 +21987,7 @@
             "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
             "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
@@ -20853,14 +22007,14 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/typescript": {
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -20899,6 +22053,7 @@
             "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
             "license": "BSD-2-Clause",
             "optional": true,
+            "peer": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
             },
@@ -20911,6 +22066,7 @@
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
             "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.3",
                 "has-bigints": "^1.0.2",
@@ -20929,6 +22085,7 @@
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
             "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.17"
             }
@@ -20937,7 +22094,8 @@
             "version": "7.16.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",
@@ -20988,6 +22146,7 @@
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
             "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -21000,6 +22159,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
             "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -21013,6 +22173,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
             "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0"
             },
@@ -21026,6 +22187,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
             "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0",
@@ -21041,6 +22203,7 @@
             "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
             "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "unist-util-is": "^6.0.0"
@@ -21054,7 +22217,8 @@
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
             "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -21109,6 +22273,7 @@
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
             "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
@@ -21118,6 +22283,7 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -21141,6 +22307,7 @@
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
             "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -21155,6 +22322,7 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -21165,6 +22333,7 @@
             "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
             "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
             }
@@ -21173,19 +22342,22 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
             "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/w3c-xmlserializer": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
             "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -21198,6 +22370,7 @@
             "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
             "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": "20 || >=22"
             }
@@ -21207,6 +22380,7 @@
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
             "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "makeerror": "1.0.12"
             }
@@ -21226,6 +22400,7 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -21236,6 +22411,7 @@
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
             "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -21248,6 +22424,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -21260,6 +22437,7 @@
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
             "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -21269,6 +22447,7 @@
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
             "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tr46": "^3.0.0",
                 "webidl-conversions": "^7.0.0"
@@ -21282,6 +22461,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -21297,6 +22477,7 @@
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
             "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-bigint": "^1.1.0",
                 "is-boolean-object": "^1.2.1",
@@ -21316,6 +22497,7 @@
             "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
             "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "function.prototype.name": "^1.1.6",
@@ -21343,6 +22525,7 @@
             "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
             "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-map": "^2.0.3",
                 "is-set": "^2.0.3",
@@ -21361,6 +22544,7 @@
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
             "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
                 "call-bind": "^1.0.8",
@@ -21381,13 +22565,15 @@
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.4.tgz",
             "integrity": "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==",
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/windows-release": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-6.1.0.tgz",
             "integrity": "sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "execa": "^8.0.1"
             },
@@ -21403,6 +22589,7 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
             "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^8.0.1",
@@ -21426,6 +22613,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
             "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -21438,6 +22626,7 @@
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
             "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=16.17.0"
             }
@@ -21447,6 +22636,7 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
             "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -21459,6 +22649,7 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -21471,6 +22662,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
             "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-key": "^4.0.0"
             },
@@ -21486,6 +22678,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
             "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mimic-fn": "^4.0.0"
             },
@@ -21501,6 +22694,7 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -21513,6 +22707,7 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -21525,6 +22720,7 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
             "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -21537,6 +22733,7 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -21545,7 +22742,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -21575,6 +22773,7 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
             "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
@@ -21588,6 +22787,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -21609,6 +22809,7 @@
             "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
             "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-wsl": "^3.1.0"
             },
@@ -21624,6 +22825,7 @@
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
             "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -21639,6 +22841,7 @@
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
             "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -21651,6 +22854,7 @@
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
             "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -21659,7 +22863,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -21727,6 +22932,7 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -21739,6 +22945,7 @@
             "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
             "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -21751,6 +22958,7 @@
             "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
             "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -21763,14 +22971,14 @@
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
             "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
             "devOptional": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/zwitch": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
             "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -21780,7 +22988,6 @@
             "name": "@taiga-ui/auto-changelog-config",
             "version": "0.408.0",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "auto-changelog": "2.5.0"
             }
@@ -21788,14 +22995,12 @@
         "projects/browserslist-config": {
             "name": "@taiga-ui/browserslist-config",
             "version": "0.408.0",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "projects/commitlint-config": {
             "name": "@taiga-ui/commitlint-config",
             "version": "0.408.0",
             "license": "Apache-2.0",
-            "peer": true,
             "peerDependencies": {
                 "@commitlint/cli": "^20.4.1",
                 "@commitlint/config-conventional": "^20.4.1",
@@ -21808,16 +23013,16 @@
             "version": "0.408.0",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@taiga-ui/auto-changelog-config": "0.406.0",
-                "@taiga-ui/browserslist-config": "0.406.0",
-                "@taiga-ui/commitlint-config": "0.406.0",
-                "@taiga-ui/cspell-config": "0.406.0",
-                "@taiga-ui/eslint-plugin-experience-next": "0.406.0",
-                "@taiga-ui/jest-config": "0.406.0",
-                "@taiga-ui/prettier-config": "0.406.0",
-                "@taiga-ui/release-it-config": "0.406.0",
-                "@taiga-ui/stylelint-config": "0.406.0",
-                "@taiga-ui/tsconfig": "0.406.0"
+                "@taiga-ui/auto-changelog-config": "0.408.0",
+                "@taiga-ui/browserslist-config": "0.408.0",
+                "@taiga-ui/commitlint-config": "0.408.0",
+                "@taiga-ui/cspell-config": "0.408.0",
+                "@taiga-ui/eslint-plugin-experience-next": "0.408.0",
+                "@taiga-ui/jest-config": "0.408.0",
+                "@taiga-ui/prettier-config": "0.408.0",
+                "@taiga-ui/release-it-config": "0.408.0",
+                "@taiga-ui/stylelint-config": "0.408.0",
+                "@taiga-ui/tsconfig": "0.408.0"
             }
         },
         "projects/cspell-config": {
@@ -21929,6 +23134,15 @@
                 "ts-jest": "^29.4.6"
             }
         },
+        "projects/oxlint-config": {
+            "name": "@taiga-ui/oxlint-config",
+            "version": "0.408.0",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "eslint-plugin-oxlint": "1.43.0",
+                "oxlint": "1.43.0"
+            }
+        },
         "projects/prettier-config": {
             "name": "@taiga-ui/prettier-config",
             "version": "0.408.0",
@@ -21959,7 +23173,7 @@
             "peerDependencies": {
                 "@stylistic/stylelint-config": "^4.0.0",
                 "@stylistic/stylelint-plugin": "^5.0.1",
-                "@taiga-ui/browserslist-config": "^0.406.0",
+                "@taiga-ui/browserslist-config": "^0.408.0",
                 "postcss": "^8.5.6",
                 "postcss-less": "^6.0.0",
                 "stylelint": "^17.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "after:bump": "npx nx build syncer && node projects/syncer/bin/src/index.js",
         "cspell": "cspell --relative --dot --gitignore .",
         "lint": "eslint .",
+        "oxlint": "oxlint",
         "prettier": "prettier !package-lock.json . --ignore-path .gitignore",
         "release": "npx nx run-many --target publish --all",
         "stylelint": "stylelint '**/*.{less,css}' --allow-empty-input --config package.json",

--- a/projects/cspell-config/configs/all.json
+++ b/projects/cspell-config/configs/all.json
@@ -681,6 +681,8 @@
         "crossfading",
         "UTDL",
         "typesafe",
-        "popout"
+        "popout",
+        "oxlint",
+        "oxlintrc"
     ]
 }

--- a/projects/oxlint-config/.npmignore
+++ b/projects/oxlint-config/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+project.json

--- a/projects/oxlint-config/.oxlintrc.json
+++ b/projects/oxlint-config/.oxlintrc.json
@@ -1,0 +1,457 @@
+{
+    "$schema": "../../node_modules/oxlint/configuration_schema.json",
+    "plugins": ["eslint", "typescript", "unicorn", "jest", "oxc", "import", "promise"],
+    "categories": {
+        "correctness": "warn"
+    },
+    "rules": {
+        "no-useless-constructor": "off",
+        "expect-expect": "off",
+        "no-useless-fallback-in-spread": "off",
+        "no-irregular-whitespace": "error",
+        "for-direction": "error",
+        "guard-for-in": "error",
+        "no-async-promise-executor": "error",
+        "max-depth": "error",
+        "no-loop-func": "error",
+        "no-array-constructor": "error",
+        "no-bitwise": "error",
+        "no-constant-condition": "error",
+        "no-control-regex": "error",
+        "no-debugger": "error",
+        "no-dupe-class-members": "error",
+        "no-delete-var": "error",
+        "no-redeclare": "error",
+        "no-dupe-else-if": "error",
+        "no-duplicate-case": "error",
+        "no-empty-character-class": "error",
+        "no-case-declarations": "error",
+        "no-unneeded-ternary": "error",
+        "no-useless-backreference": "error",
+        "no-constant-binary-expression": "error",
+        "no-compare-neg-zero": "error",
+        "no-nested-ternary": "error",
+        "default-param-last": "error",
+        "no-cond-assign": "error",
+        "no-empty-pattern": "error",
+        "no-empty-static-block": "error",
+        "no-ex-assign": "error",
+        "no-extra-boolean-cast": "error",
+        "no-fallthrough": "error",
+        "no-global-assign": "error",
+        "no-invalid-regexp": "error",
+        "no-loss-of-precision": "error",
+        "no-nonoctal-decimal-escape": "error",
+        "no-shadow-restricted-names": "error",
+        "no-sparse-arrays": "error",
+        "no-unexpected-multiline": "error",
+        "no-unsafe-finally": "error",
+        "no-unsafe-optional-chaining": "error",
+        "no-self-assign": "error",
+        "no-regex-spaces": "error",
+        "no-unused-labels": "error",
+        "no-useless-catch": "error",
+        "no-useless-concat": "error",
+        "no-useless-escape": "error",
+        "no-var": "error",
+        "prefer-template": "error",
+        "prefer-rest-params": "error",
+        "require-yield": "error",
+        "use-isnan": "error",
+        "valid-typeof": "error",
+        "vars-on-top": "error",
+        "prefer-spread": "error",
+        "curly": ["error", "all"],
+        "max-nested-callbacks": ["error", 4],
+        "eqeqeq": ["error", "always", {"null": "ignore"}],
+        "no-return-assign": ["error", "always"],
+        "func-style": [
+            "error",
+            "declaration",
+            {
+                "allowArrowFunctions": true
+            }
+        ],
+        "max-params": [
+            "error",
+            {
+                "countVoidThis": true,
+                "max": 5
+            }
+        ],
+        "no-implicit-coercion": [
+            "error",
+            {
+                "allow": ["!!"]
+            }
+        ],
+        "no-restricted-imports": [
+            "error",
+            {
+                "patterns": [
+                    {
+                        "group": ["rxjs/operators"],
+                        "message": "Don't use 'rxjs/operators' instead of 'rxjs'"
+                    },
+                    {
+                        "group": ["@angular/**"],
+                        "importNames": ["Inject"],
+                        "message": "Please use `inject(Type)` function instead"
+                    },
+                    {
+                        "group": ["@taiga-ui/polymorpheus"],
+                        "importNames": ["POLYMORPHEUS_CONTEXT"],
+                        "message": "Please use `injectContext()` function instead"
+                    },
+                    {
+                        "group": ["@angular/core"],
+                        "importNames": ["Attribute"],
+                        "message": "Always prefer using HostAttributeToken over @Attribute. See: https://angular.dev/api/core/HostAttributeToken"
+                    }
+                ]
+            }
+        ],
+        "no-console": [
+            "error",
+            {
+                "allow": ["info", "assert", "warn", "error"]
+            }
+        ],
+        "no-empty-function": [
+            "error",
+            {
+                "allow": [
+                    "methods",
+                    "arrowFunctions",
+                    "private-constructors",
+                    "protected-constructors",
+                    "overrideMethods",
+                    "decoratedFunctions"
+                ]
+            }
+        ],
+        "no-empty": [
+            "error",
+            {
+                "allowEmptyCatch": true
+            }
+        ],
+        "no-unused-expressions": [
+            "error",
+            {
+                "allowShortCircuit": true,
+                "allowTaggedTemplates": false,
+                "allowTernary": false
+            }
+        ],
+        "no-useless-rename": [
+            "error",
+            {
+                "ignoreDestructuring": true,
+                "ignoreExport": false,
+                "ignoreImport": false
+            }
+        ],
+        "no-void": [
+            "error",
+            {
+                "allowAsStatement": true
+            }
+        ],
+        "no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_"
+            }
+        ],
+
+        "import/no-named-as-default": "warn",
+        "import/no-named-as-default-member": "warn",
+        "import/default": "error",
+        "import/first": "error",
+        "import/no-absolute-path": "error",
+        "import/no-mutable-exports": "error",
+        "import/namespace": "error",
+        "import/no-cycle": "error",
+        "import/no-self-import": "error",
+        "import/no-webpack-loader-syntax": "error",
+        "import/consistent-type-specifier-style": ["error", "prefer-inline"],
+        "import/no-duplicates": [
+            "error",
+            {
+                "prefer-inline": true
+            }
+        ],
+
+        "jest/no-disabled-tests": "off",
+        "jest/no-commented-out-tests": "warn",
+        "jest/no-alias-methods": "error",
+        "jest/no-conditional-expect": "error",
+        "jest/no-export": "error",
+        "jest/no-focused-tests": "error",
+        "jest/no-identical-title": "error",
+        "jest/no-interpolation-in-snapshots": "error",
+        "jest/no-jasmine-globals": "error",
+        "jest/no-mocks-import": "error",
+        "jest/no-test-prefixes": "error",
+        "jest/valid-describe-callback": "error",
+        "jest/valid-expect": "error",
+        "jest/valid-title": "error",
+        "jest/no-standalone-expect": [
+            "error",
+            {
+                "additionalTestBlockFunctions": ["fakeAsync"]
+            }
+        ],
+        "jest/prefer-lowercase-title": [
+            "error",
+            {
+                "allowedPrefixes": [
+                    "Tui",
+                    "NaN",
+                    "UTC",
+                    "January",
+                    "February",
+                    "March",
+                    "April",
+                    "May",
+                    "June",
+                    "July",
+                    "August",
+                    "September",
+                    "October",
+                    "November",
+                    "December"
+                ],
+                "ignore": ["describe", "test"]
+            }
+        ],
+        "jest/require-top-level-describe": [
+            "error",
+            {
+                "maxNumberOfTopLevelDescribes": 1
+            }
+        ],
+
+        "promise/no-callback-in-promise": "off",
+        "promise/no-promise-in-callback": "warn",
+        "promise/valid-params": "warn",
+        "promise/no-return-wrap": "error",
+        "promise/param-names": "error",
+        "promise/no-new-statics": "error",
+
+        "unicorn/prefer-string-replace-all": "error",
+        "unicorn/consistent-empty-array-spread": "error",
+        "unicorn/escape-case": "error",
+        "unicorn/new-for-builtins": "error",
+        "unicorn/no-array-method-this-argument": "error",
+        "unicorn/no-await-in-promise-methods": "error",
+        "unicorn/no-empty-file": "error",
+        "unicorn/no-magic-array-flat-depth": "error",
+        "unicorn/no-negation-in-equality-check": "error",
+        "unicorn/no-new-array": "error",
+        "unicorn/no-single-promise-in-promise-methods": "error",
+        "unicorn/no-typeof-undefined": "error",
+        "unicorn/no-useless-spread": "error",
+        "unicorn/prefer-logical-operator-over-ternary": "error",
+        "unicorn/prefer-query-selector": "error",
+        "unicorn/prefer-set-size": "error",
+        "unicorn/prefer-string-raw": "error",
+        "unicorn/prefer-string-slice": "error",
+        "unicorn/require-number-to-fixed-digits-argument": "error",
+        "unicorn/filename-case": [
+            "error",
+            {
+                "case": "kebabCase"
+            }
+        ],
+
+        "typescript/ban-tslint-comment": "error",
+        "typescript/consistent-generic-constructors": "error",
+        "typescript/consistent-indexed-object-style": "error",
+        "typescript/consistent-type-definitions": "error",
+        "typescript/no-inferrable-types": "error",
+        "typescript/no-confusing-non-null-assertion": "error",
+        "typescript/no-unnecessary-type-constraint": "error",
+        "typescript/no-duplicate-enum-values": "error",
+        "typescript/no-dynamic-delete": "error",
+        "typescript/no-empty-object-type": "error",
+        "typescript/no-extra-non-null-assertion": "error",
+        "typescript/no-misused-new": "error",
+        "typescript/no-non-null-asserted-nullish-coalescing": "error",
+        "typescript/no-non-null-asserted-optional-chain": "error",
+        "typescript/no-this-alias": "error",
+        "typescript/no-unnecessary-parameter-property-assignment": "error",
+        "typescript/no-unnecessary-type-arguments": "error",
+        "typescript/no-unsafe-declaration-merging": "error",
+        "typescript/no-unsafe-function-type": "error",
+        "typescript/no-useless-empty-export": "error",
+        "typescript/no-wrapper-object-types": "error",
+        "typescript/prefer-as-const": "error",
+        "typescript/prefer-enum-initializers": "error",
+        "typescript/prefer-for-of": "error",
+        "typescript/prefer-function-type": "error",
+        "typescript/prefer-literal-enum-member": "error",
+        "typescript/prefer-namespace-keyword": "error",
+        "typescript/await-thenable": "error",
+        "typescript/no-array-delete": "error",
+        "typescript/use-unknown-in-catch-callback-variable": "error",
+        "typescript/return-await": "error",
+        "typescript/restrict-plus-operands": "error",
+        "typescript/require-await": "error",
+        "typescript/require-array-sort-compare": "error",
+        "typescript/related-getter-setter-pairs": "error",
+        "typescript/prefer-return-this-type": "error",
+        "typescript/prefer-reduce-type-parameter": "error",
+        "typescript/prefer-promise-reject-errors": "error",
+        "typescript/prefer-includes": "error",
+        "typescript/only-throw-error": "error",
+        "typescript/no-unsafe-unary-minus": "error",
+        "typescript/no-unsafe-enum-comparison": "error",
+        "typescript/no-unnecessary-type-assertion": "error",
+        "typescript/non-nullable-type-assertion-style": "error",
+        "typescript/no-unnecessary-boolean-literal-compare": "error",
+        "typescript/no-redundant-type-constituents": "error",
+        "typescript/no-mixed-enums": "error",
+        "typescript/no-meaningless-void-operator": "error",
+        "typescript/no-implied-eval": "error",
+        "typescript/no-for-in-array": "error",
+        "typescript/no-duplicate-type-constituents": "error",
+        "typescript/array-type": [
+            "error",
+            {
+                "default": "array-simple",
+                "readonly": "array-simple"
+            }
+        ],
+        "typescript/consistent-type-imports": [
+            "error",
+            {
+                "disallowTypeAnnotations": false,
+                "fixStyle": "inline-type-imports",
+                "prefer": "type-imports"
+            }
+        ],
+        "typescript/explicit-function-return-type": [
+            "error",
+            {
+                "allowConciseArrowFunctionExpressionsStartingWithVoid": true,
+                "allowDirectConstAssertionInArrowFunctions": true,
+                "allowExpressions": true,
+                "allowHigherOrderFunctions": true,
+                "allowTypedFunctionExpressions": true
+            }
+        ],
+        "typescript/no-extraneous-class": [
+            "error",
+            {
+                "allowConstructorOnly": true,
+                "allowEmpty": false,
+                "allowStaticOnly": true,
+                "allowWithDecorator": true
+            }
+        ],
+        "typescript/no-namespace": [
+            "error",
+            {
+                "allowDeclarations": true
+            }
+        ],
+        "typescript/no-restricted-types": [
+            "error",
+            {
+                "types": {
+                    "BigInt": {
+                        "fixWith": "bigint",
+                        "message": "Use bigint instead"
+                    },
+                    "Boolean": {
+                        "fixWith": "boolean",
+                        "message": "Use boolean instead"
+                    },
+                    "Number": {
+                        "fixWith": "number",
+                        "message": "Use number instead"
+                    },
+                    "String": {
+                        "fixWith": "string",
+                        "message": "Use string instead"
+                    },
+                    "Symbol": {
+                        "fixWith": "symbol",
+                        "message": "Use symbol instead"
+                    },
+                    "{}": {
+                        "fixWith": "Record<string, unknown>",
+                        "message": "`{}` actually means `any non-nullish value`.\n- If you want a type meaning `any object`, you probably want `object` instead.\n- If you want a type meaning `any value`, you probably want `unknown` instead.\n- If you want a type meaning `empty object`, you probably want `Record<string, never>` instead."
+                    }
+                }
+            }
+        ],
+        "typescript/triple-slash-reference": [
+            "error",
+            {
+                "lib": "always",
+                "path": "always",
+                "types": "always"
+            }
+        ],
+        "typescript/switch-exhaustiveness-check": [
+            "error",
+            {
+                "considerDefaultExhaustiveForUnions": true,
+                "allowDefaultCaseForExhaustiveSwitch": true,
+                "requireDefaultForNonUnion": false
+            }
+        ],
+        "typescript/promise-function-async": [
+            "error",
+            {
+                "allowedPromiseNames": ["Thenable"],
+                "checkArrowFunctions": true,
+                "checkFunctionDeclarations": true,
+                "checkFunctionExpressions": true,
+                "checkMethodDeclarations": true
+            }
+        ]
+    },
+    "overrides": [
+        {
+            "files": ["**/*.spec.ts", "**/*.cy.ts"],
+            "rules": {
+                "max-nested-callbacks": "off",
+                "no-irregular-whitespace": "off",
+                "typescript/no-extraneous-class": "off",
+                "no-restricted-imports": "off"
+            }
+        },
+        {
+            "files": ["**/*.md", "**/*.html"],
+            "rules": {"no-irregular-whitespace": "off"}
+        },
+        {
+            "files": ["**/*.pw.spec.ts"],
+            "rules": {
+                "no-empty-pattern": "off"
+            }
+        }
+    ],
+    "ignorePatterns": [
+        "**/tests-report/**",
+        "**/snapshots/**",
+        "**/test-results/**",
+        "**/.nx/**",
+        "*.{jpg,svg,less,scss,txt,png,webmanifest,pdf,mp3,ogv,mp4,xml}",
+        "**/node_modules/**",
+        "**/*@dasherize__/**",
+        "**/coverage/**",
+        "**/*.d.ts",
+        "**/dist/**",
+        "**/bin/**",
+        "**/.cache/**",
+        "**/.angular/**",
+        "**.git/**",
+        "**/.idea/**",
+        "**/LICENSE"
+    ]
+}

--- a/projects/oxlint-config/README.md
+++ b/projects/oxlint-config/README.md
@@ -1,0 +1,98 @@
+### `@taiga-ui/oxlint-config`
+
+**Important**: Experimental tool. It has partial support for the original rules from
+`@taiga-ui/eslint-plugin-experience-next`
+
+[Oxlint](https://oxc.rs/docs/guide/usage/linter.html) - The alternative for Eslint with features:
+
+- 50-100 times faster
+- Backward compatibility with Eslint
+
+```shell
+npm i -D @taiga-ui/oxlint-config
+```
+
+#### Usage: Eslint + Oxlint
+
+In the eslint configuration, disable all out-of-the-box oxlint rules using
+[eslint-plugin-oxlint](https://github.com/oxc-project/eslint-plugin-oxlint):
+
+```ts
+// eslint.config.ts
+import oxlint from 'eslint-plugin-oxlint';
+
+export default [
+  // other plugins
+  ...oxlint.configs['flat/all'], // oxlint should be the last one
+];
+```
+
+Create oxlint config:
+
+```json5
+// .oxlintrc.json
+{
+  $schema: './node_modules/oxlint/configuration_schema.json',
+  extends: ['./node_modules/@taiga-ui/oxlint-config/.oxlintrc.json'],
+}
+```
+
+**Important**: Temporarily not supported `extends` from short imports - https://github.com/oxc-project/oxc/issues/15538
+
+Run linters:
+
+```shell
+oxlint && eslint
+```
+
+For fix use flag `--fix`:
+
+```shell
+oxlint --fix && eslint --fix
+```
+
+Disabling eslint rules based on oxlint config is supported:
+
+```js
+// eslint.config.js
+import oxlint from 'eslint-plugin-oxlint';
+export default [
+  // other plugins
+  ...oxlint.buildFromOxlintConfigFile('./.oxlintrc.json'),
+];
+```
+
+#### Usage: Oxlint
+
+Create oxlint config:
+
+```json5
+// .oxlintrc.json
+{
+  $schema: './node_modules/oxlint/configuration_schema.json',
+  extends: ['./node_modules/@taiga-ui/oxlint-config/.oxlintrc.json'],
+}
+```
+
+**Important**: Temporarily not supported `extends` from short imports - https://github.com/oxc-project/oxc/issues/15538
+
+Run linter:
+
+```shell
+oxlint
+```
+
+For fix use flag `--fix`:
+
+```shell
+oxlint --fix
+```
+
+#### Usage: Nx
+
+The [nx-oxlint](https://github.com/Nas3nmann/nx-oxlint) plugin is available for working with nx
+
+#### Usage: IDE
+
+- Jetbrains - [oxc](https://plugins.jetbrains.com/plugin/27061-oxc)
+- VSCode - [oxc](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode)

--- a/projects/oxlint-config/package.json
+++ b/projects/oxlint-config/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@taiga-ui/oxlint-config",
-    "version": "0.403.0",
+    "version": "0.408.0",
     "description": "Taiga UI oxlint config",
     "keywords": [
         "oxlint"

--- a/projects/oxlint-config/package.json
+++ b/projects/oxlint-config/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@taiga-ui/oxlint-config",
+    "version": "0.403.0",
+    "description": "Taiga UI oxlint config",
+    "keywords": [
+        "oxlint"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/taiga-family/configurations.git"
+    },
+    "license": "Apache-2.0",
+    "main": ".oxlintrc.json",
+    "peerDependencies": {
+        "eslint-plugin-oxlint": "1.43.0",
+        "oxlint": "1.43.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/projects/oxlint-config/project.json
+++ b/projects/oxlint-config/project.json
@@ -1,0 +1,15 @@
+{
+    "name": "oxlint-config",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "prefix": "tui",
+    "projectType": "library",
+    "sourceRoot": "projects/oxlint-config",
+    "targets": {
+        "publish": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "npm publish ./projects/{projectName} --access=public --ignore-scripts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add basic oxlint config. During the implementation of the configuration, I used the rules settings from eslint-plugin-experience-next (recommended) and only those rules that are already ready in oxlint

Test oxlint config in [taiga-ui](https://github.com/taiga-family/taiga-ui)
|Usage|Time|
|---|---|
|eslint|124.78s|
|eslint + oxlint|62.29s(eslint) + 0.89s(oxlint)|

I think the basic idea of the following steps is:
- simplify the configuration of the oxlint config
  - when updating the oxlint library, semi-automatically detect new rules and the need to enable them based on eslint-plugin-experience-next
  - when updating eslint-plugin-experience-next, semi-automatically detect the changed rules for oxlint
- try to untie the oxlint config from the eslint config
  - try to enable js plugins - https://oxc.rs/docs/guide/usage/linter/js-plugins.html
  - define the missing rules for the complete abandonment of eslint
  - rewrite custom taiga-ui eslint rules in rust for oxlint support
  - enable oxlint config on github ci in this repository

Fixes #1474

