### PR TITLE
fix(stylelint-config): specify order for `inset` in `order/properties-order` rule

### DIFF
--- a/projects/stylelint-config/index.js
+++ b/projects/stylelint-config/index.js
@@ -172,6 +172,7 @@ module.exports = {
                 'all',
                 'content',
                 'position',
+                'inset',
                 {
                     order: 'flexible',
                     properties: ['top', 'left', 'right', 'bottom'],


### PR DESCRIPTION
```css
inset: 0;
left: -1rem;
right: -1rem;
```

throws
```
Expected "left" to come before "inset" (order/properties-order)
Stylelint order/properties-order
```

## But
```css
left: -1rem;
right: -1rem;
inset: 0;
```
throws
```
Unexpected shorthand "inset" after "right" (declaration-block-no-shorthand-property-overrides)
Stylelint declaration-block-no-shorthand-property-overrides
```