### PR TITLE
fix(eslint-plugin-experience-next): use `localeCompare` in standalone-imports-sort

### DIFF
--- a/projects/eslint-plugin-experience-next/rules/utils/sorting/get-sorted-names.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/sorting/get-sorted-names.ts
@@ -3,11 +3,13 @@ import {type TSESLint, type TSESTree} from '@typescript-eslint/utils';
 import {isSpread} from '../ast/is-spread';
 import {nameOf} from '../ast/name-of';
 
+const IMPORT_NAME_COLLATOR = new Intl.Collator('en', {numeric: true});
+
 /**
- * Sorts Angular standalone import elements into a deterministic, alphabetical order.
+ * Sorts Angular standalone import elements into a deterministic, natural order.
  *
  * The sorting rules:
- * 1. Regular elements (Identifiers, MemberExpressions, etc.) are sorted alphabetically.
+ * 1. Regular elements (Identifiers, MemberExpressions, etc.) are sorted naturally.
  * 2. Spread elements (e.g. `...A`) are sorted separately and placed after regular ones.
  * 3. Sorting is based on the string value returned by `nameOf()`.
  *
@@ -31,12 +33,16 @@ export function getSortedNames(
     const spreads = elements.filter((e) => isSpread(e));
 
     const sortedRegular = [...regular].sort((a, b) =>
-        nameOf(a, source).localeCompare(nameOf(b, source)),
+        compareImportNames(nameOf(a, source), nameOf(b, source)),
     );
 
     const sortedSpreads = [...spreads].sort((a, b) =>
-        nameOf(a.argument, source).localeCompare(nameOf(b.argument, source)),
+        compareImportNames(nameOf(a.argument, source), nameOf(b.argument, source)),
     );
 
     return [...sortedRegular, ...sortedSpreads].map((n) => nameOf(n, source));
+}
+
+function compareImportNames(x: string, y: string): number {
+    return IMPORT_NAME_COLLATOR.compare(x, y);
 }

--- a/projects/eslint-plugin-experience-next/tests/standalone-imports-sort.spec.ts
+++ b/projects/eslint-plugin-experience-next/tests/standalone-imports-sort.spec.ts
@@ -144,6 +144,32 @@ ruleTester.run('standalone-imports-sort', rule, {
                 class Test {}
             `,
         },
+        {
+            code: `
+                @Component({
+                    imports: [
+                        MaskitoDirective,
+                        NumberMaskDocExample1,
+                        NumberMaskDocExample10,
+                        NumberMaskDocExample2,
+                        NumberMaskDocExample3,
+                    ]
+                })
+                class Test {}
+            `,
+            errors: [
+                {
+                    message:
+                        'Order in imports should be [MaskitoDirective, NumberMaskDocExample1, NumberMaskDocExample2, NumberMaskDocExample3, NumberMaskDocExample10]',
+                },
+            ],
+            output: `
+                @Component({
+                    imports: [MaskitoDirective, NumberMaskDocExample1, NumberMaskDocExample2, NumberMaskDocExample3, NumberMaskDocExample10]
+                })
+                class Test {}
+            `,
+        },
     ],
     valid: [
         {
@@ -215,6 +241,20 @@ ruleTester.run('standalone-imports-sort', rule, {
                     styleUrl: './index.less',
                     encapsulation,
                     changeDetection,
+                })
+                class TestComponent {}
+            `,
+        },
+        {
+            code: `
+                @Component({
+                    imports: [
+                        MaskitoDirective,
+                        NumberMaskDocExample1,
+                        NumberMaskDocExample2,
+                        NumberMaskDocExample3,
+                        NumberMaskDocExample10,
+                    ]
                 })
                 class TestComponent {}
             `,


### PR DESCRIPTION


Fixes #1773