### PR TITLE
 fix: `single-line-class-property-spacing` require blank line only after multiline fields, not before

### DIFF
--- a/projects/eslint-plugin-experience-next/configs/recommended.ts
+++ b/projects/eslint-plugin-experience-next/configs/recommended.ts
@@ -775,7 +775,7 @@ export default defineConfig([
             '@taiga-ui/experience-next/prefer-untracked-incidental-signal-reads': 'error',
             '@taiga-ui/experience-next/prefer-untracked-signal-getter': 'error',
             '@taiga-ui/experience-next/short-tui-imports': 'error',
-            '@taiga-ui/experience-next/single-line-class-property-spacing': 'off',
+            '@taiga-ui/experience-next/single-line-class-property-spacing': 'error',
             '@taiga-ui/experience-next/single-line-variable-spacing': 'error',
             '@taiga-ui/experience-next/standalone-imports-sort': [
                 'error',

--- a/projects/eslint-plugin-experience-next/configs/recommended.ts
+++ b/projects/eslint-plugin-experience-next/configs/recommended.ts
@@ -775,7 +775,7 @@ export default defineConfig([
             '@taiga-ui/experience-next/prefer-untracked-incidental-signal-reads': 'error',
             '@taiga-ui/experience-next/prefer-untracked-signal-getter': 'error',
             '@taiga-ui/experience-next/short-tui-imports': 'error',
-            '@taiga-ui/experience-next/single-line-class-property-spacing': 'error',
+            '@taiga-ui/experience-next/single-line-class-property-spacing': 'off',
             '@taiga-ui/experience-next/single-line-variable-spacing': 'error',
             '@taiga-ui/experience-next/standalone-imports-sort': [
                 'error',

--- a/projects/eslint-plugin-experience-next/docs/single-line-class-property-spacing.md
+++ b/projects/eslint-plugin-experience-next/docs/single-line-class-property-spacing.md
@@ -3,11 +3,11 @@
 <sup>`✅ Recommended`</sup> <sup>`Fixable`</sup>
 
 Keeps consecutive single-line field-like class members visually grouped inside the same accessibility group, including
-`abstract` fields. A multiline field must be separated from neighboring field-like members with a blank line before it
-and, when another field follows, a blank line after it. `get` and `set` accessors always act as visual boundaries and
-must be separated from surrounding fields by a blank line. This removes noisy empty lines inside simple field groups
-without flattening longer, wrapped initializers, blending fields into accessors, or conflicting with accessibility-group
-spacing.
+`abstract` fields. When another field follows a multiline field, it must be separated from that field with a blank line
+after it; a blank line before a multiline field is not required. `get` and `set` accessors always act as visual
+boundaries and must be separated from surrounding fields by a blank line. This removes noisy empty lines inside simple
+field groups without flattening longer, wrapped initializers, blending fields into accessors, or conflicting with
+accessibility-group spacing.
 
 ```ts
 // ❌ error
@@ -24,7 +24,6 @@ class TuiEditorStarter {
 class TuiEditorStarter {
   protected readonly template = import('./import/template.md?raw');
   protected readonly component = import('./import/component.md?raw');
-
   protected readonly exampleIcons =
     import('./import/angular-to-long-long-long-long-long-long-long-text-for-prettier.json.md?raw');
 

--- a/projects/eslint-plugin-experience-next/rules/recommended/single-line-class-property-spacing.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/single-line-class-property-spacing.ts
@@ -17,7 +17,6 @@ import {createRule} from '../utils/create-rule';
 type MessageIds =
     | 'missingBlankLineAfterMultilineProperty'
     | 'missingBlankLineAroundAccessor'
-    | 'missingBlankLineBeforeMultilineProperty'
     | 'unexpectedBlankLineBeforeNextSingleLineField';
 
 export const rule = createRule<[], MessageIds>({
@@ -108,31 +107,6 @@ export const rule = createRule<[], MessageIds>({
                     if (
                         isFieldLikeMember(current) &&
                         isFieldLikeMember(next) &&
-                        currentIsSingleLine &&
-                        !nextIsSingleLine &&
-                        !blankLineBetween
-                    ) {
-                        context.report({
-                            fix: (fixer) =>
-                                fixer.replaceTextRange(
-                                    [current.range[1], next.range[0]],
-                                    getSpacingReplacement(
-                                        sourceCode,
-                                        betweenText,
-                                        next.loc.start.line,
-                                        1,
-                                    ),
-                                ),
-                            messageId: 'missingBlankLineBeforeMultilineProperty',
-                            node: next,
-                        });
-
-                        continue;
-                    }
-
-                    if (
-                        isFieldLikeMember(current) &&
-                        isFieldLikeMember(next) &&
                         !currentIsSingleLine &&
                         !blankLineBetween
                     ) {
@@ -166,8 +140,6 @@ export const rule = createRule<[], MessageIds>({
                 'Multiline field-like members should be followed by a blank line before the next field',
             missingBlankLineAroundAccessor:
                 'Getter and setter members should be separated from surrounding fields by a blank line',
-            missingBlankLineBeforeMultilineProperty:
-                'Multiline field-like members should be preceded by a blank line after single-line fields',
             unexpectedBlankLineBeforeNextSingleLineField:
                 'Single-line fields should not be separated by a blank line before the next single-line field',
         },

--- a/projects/eslint-plugin-experience-next/tests/single-line-class-property-spacing.spec.ts
+++ b/projects/eslint-plugin-experience-next/tests/single-line-class-property-spacing.spec.ts
@@ -62,42 +62,16 @@ ruleTester.run('single-line-class-property-spacing', rule, {
             code: `
                 class TestClass {
                     protected readonly template = import('./template.md?raw');
-                    protected readonly component = import('./component.md?raw');
-                    protected readonly exampleIcons = import(
-                        './angular-to-long-text-for-prettier.json.md?raw'
-                    );
-                }
-            `,
-            errors: [{messageId: 'missingBlankLineBeforeMultilineProperty'}],
-            output: `
-                class TestClass {
-                    protected readonly template = import('./template.md?raw');
-                    protected readonly component = import('./component.md?raw');
-
-                    protected readonly exampleIcons = import(
-                        './angular-to-long-text-for-prettier.json.md?raw'
-                    );
-                }
-            `,
-        },
-        {
-            code: `
-                class TestClass {
-                    protected readonly template = import('./template.md?raw');
                     protected readonly exampleIcons = import(
                         './angular-to-long-text-for-prettier.json.md?raw'
                     );
                     protected readonly template2 = import('./template-2.md?raw');
                 }
             `,
-            errors: [
-                {messageId: 'missingBlankLineBeforeMultilineProperty'},
-                {messageId: 'missingBlankLineAfterMultilineProperty'},
-            ],
+            errors: [{messageId: 'missingBlankLineAfterMultilineProperty'}],
             output: `
                 class TestClass {
                     protected readonly template = import('./template.md?raw');
-
                     protected readonly exampleIcons = import(
                         './angular-to-long-text-for-prettier.json.md?raw'
                     );
@@ -234,6 +208,17 @@ ruleTester.run('single-line-class-property-spacing', rule, {
         },
     ],
     valid: [
+        {
+            code: `
+                class TestClass {
+                    protected readonly template = import('./template.md?raw');
+                    protected readonly component = import('./component.md?raw');
+                    protected readonly exampleIcons = import(
+                        './angular-to-long-text-for-prettier.json.md?raw'
+                    );
+                }
+            `,
+        },
         {
             code: `
                 class TestClass {


### PR DESCRIPTION
Fixes # <!-- link to a relevant issue. -->
