### PR TITLE
fix(eslint-plugin-experience-next): `unicorn/filename-case` rule should use recommended configuration for React projects

### DIFF
--- a/projects/eslint-plugin-experience-next/configs/recommended.ts
+++ b/projects/eslint-plugin-experience-next/configs/recommended.ts
@@ -1005,7 +1005,16 @@ export default defineConfig([
                     selector: 'function',
                 },
             ],
-            'unicorn/filename-case': ['error', {case: 'camelCase'}],
+        },
+    },
+    {
+        files: ['**/*.{jsx,tsx}'],
+        ignores: ['**/*.cy.{jsx,tsx}'],
+        rules: {
+            'unicorn/filename-case': [
+                'error',
+                {case: 'pascalCase', checkDirectories: false},
+            ],
         },
     },
     {


### PR DESCRIPTION
Explore: 
- https://github.com/taiga-family/maskito/pull/2825

```
/../projects/demo-integrations/src/tests/component-testing/react/async-predicate-options-race/reactApp.tsx

Error:   1:1  error  
Directory name `demo-integrations` is not in camel case. 
Rename it to `demoIntegrations`  unicorn/filename-case

# [...]
```

<details><summary>Show more logs</summary>
<p>

```
/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/async-predicate-options-race/reactApp.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/async-predicate-options-race/reactAsyncPredicateOptionsRace.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/async-predicates-race/reactApp.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/async-predicates-race/reactAsyncPredicatesRace.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/awesomeInput.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/change-event/changeEvent.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/react-native/card.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/react-native/maskedInput.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/react-native/number.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/react-native/phone.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo-integrations/src/tests/component-testing/react/react-native/time.cy.tsx
Error:   1:1  error  Directory name `demo-integrations` is not in camel case. Rename it to `demoIntegrations`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react-native/examples/controlledInput.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react-native/examples/kitCompatible.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react-native/examples/poorPluginSupport.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react-native/examples/useMaskitoBasicUsage.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/1-use-maskito-basic-usage/example.component.tsx
Error:   1:1  error  Directory name `1-use-maskito-basic-usage` is not in camel case. Rename it to `1UseMaskitoBasicUsage`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/1-use-maskito-basic-usage/useMaskitoBasicUsage.tsx
Error:   1:1  error  Directory name `1-use-maskito-basic-usage` is not in camel case. Rename it to `1UseMaskitoBasicUsage`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/2-element-predicate/awesomeInput.tsx
Error:   1:1  error  Directory name `2-element-predicate` is not in camel case. Rename it to `2ElementPredicate`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/2-element-predicate/example.component.tsx
Error:   1:1  error  Directory name `2-element-predicate` is not in camel case. Rename it to `2ElementPredicate`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/2-element-predicate/index.tsx
Error:   1:1  error  Directory name `2-element-predicate` is not in camel case. Rename it to `2ElementPredicate`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/demo/src/pages/frameworks/react/examples/3-merge-ref/index.tsx
Error:   1:1  error  Directory name `3-merge-ref` is not in camel case. Rename it to `3MergeRef`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/tests/card.spec.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/tests/maskedInput.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/tests/number.spec.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/tests/phone.spec.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/tests/time.spec.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case

/home/runner/work/maskito/maskito/projects/react-native/src/lib/useMaskito.tsx
Error:   1:1  error  Directory name `react-native` is not in camel case. Rename it to `reactNative`  unicorn/filename-case
```

</p>
</details> 


### New behavior

`unicorn/filename-case` rule docs [recommends](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md#cases-1) the such configuration.

```
> eslint . --fix

projects/demo-integrations/src/tests/component-testing/react/async-predicate-options-race/reactApp.tsx
  1:1  error  Filename is not in pascal case. Rename it to `ReactApp.tsx`  unicorn/filename-case

projects/demo-integrations/src/tests/component-testing/react/async-predicate-options-race/reactAsyncPredicateOptionsRace.cy.tsx
  1:1  error  Filename is not in kebab case. Rename it to `react-async-predicate-options-race.cy.tsx`  unicorn/filename-case

projects/demo-integrations/src/tests/component-testing/react/async-predicates-race/reactApp.tsx
  1:1  error  Filename is not in pascal case. Rename it to `ReactApp.tsx`  unicorn/filename-case

projects/demo-integrations/src/tests/component-testing/react/async-predicates-race/reactAsyncPredicatesRace.cy.tsx
  1:1  error  Filename is not in kebab case. Rename it to `react-async-predicates-race.cy.tsx`  unicorn/filename-case

projects/demo-integrations/src/tests/component-testing/react/awesomeInput.tsx
  1:1  error  Filename is not in pascal case. Rename it to `AwesomeInput.tsx`  unicorn/filename-case

projects/demo-integrations/src/tests/component-testing/react/change-event/changeEvent.cy.tsx
  1:1  error  Filename is not in kebab case. Rename it to `change-event.cy.tsx`  unicorn/filename-case

# [...]

projects/react/src/lib/tests/elementPredicate.spec.tsx
  1:1  error  Filename is not in pascal case. Rename it to `ElementPredicate.spec.tsx`  unicorn/filename-case

projects/react/src/lib/tests/useMaskito.spec.tsx
  1:1  error  Filename is not in pascal case. Rename it to `UseMaskito.spec.tsx`  unicorn/filename-case

projects/react/src/lib/useIsomorphicLayoutEffect.tsx
  1:1  error  Filename is not in pascal case. Rename it to `UseIsomorphicLayoutEffect.tsx`  unicorn/filename-case

projects/react/src/lib/useMaskito.tsx
  1:1  error  Filename is not in pascal case. Rename it to `UseMaskito.tsx`  unicorn/filename-case

✖ 27 problems (27 errors, 0 warnings)
```