### PR TITLE
feat(deps): bump `@release-it/conventional-changelog` 11 => 12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,8 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('<rule-name>', rule, {
-  invalid: [
-    /* … */
-  ],
-  valid: [
-    /* … */
-  ],
+  invalid: [/* … */],
+  valid: [/* … */],
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,13 +2543,13 @@
             "peer": true
         },
         "node_modules/@cacheable/memory": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
-            "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+            "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@cacheable/utils": "^2.4.1",
+                "@cacheable/utils": "^2.5.0",
                 "@keyv/bigmap": "^1.3.1",
                 "hookified": "^1.15.1",
                 "keyv": "^5.6.0"
@@ -2583,9 +2583,9 @@
             }
         },
         "node_modules/@cacheable/utils": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
-            "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+            "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2604,18 +2604,18 @@
             }
         },
         "node_modules/@commitlint/cli": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.1.0.tgz",
-            "integrity": "sha512-CVwY6TxGv5naEaWxBdgNHko1xgL95Mb4WcIqp9iik33H0ctVqRv6YtekCntayhEP0T/apuiGvHu5HcCwFuVxEA==",
+            "version": "21.2.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
+            "integrity": "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/config-conventional": "^21.1.0",
-                "@commitlint/format": "^21.1.0",
-                "@commitlint/lint": "^21.1.0",
-                "@commitlint/load": "^21.1.0",
-                "@commitlint/read": "^21.1.0",
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/config-conventional": "^21.2.0",
+                "@commitlint/format": "^21.2.0",
+                "@commitlint/lint": "^21.2.0",
+                "@commitlint/load": "^21.2.0",
+                "@commitlint/read": "^21.2.1",
+                "@commitlint/types": "^21.2.0",
                 "tinyexec": "^1.0.0",
                 "yargs": "^18.0.0"
             },
@@ -2673,16 +2673,16 @@
             }
         },
         "node_modules/@commitlint/cli/node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "version": "18.1.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+            "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
+                "string-width": "^8.2.1",
                 "y18n": "^5.0.5",
                 "yargs-parser": "^22.0.0"
             },
@@ -2700,27 +2700,44 @@
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
+        "node_modules/@commitlint/cli/node_modules/yargs/node_modules/string-width": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@commitlint/config-conventional": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.1.0.tgz",
-            "integrity": "sha512-BIFl8xM+3SLy3jrblUC3wmQLCVbLty+++6o859BDCmybVrQdXmIWO+dlkGIbv/M2bBoC55wGuh0zGiw3TPjL1g==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+            "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
             "license": "MIT",
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
-                "conventional-changelog-conventionalcommits": "^9.2.0"
+                "@commitlint/types": "^21.2.0",
+                "conventional-changelog-conventionalcommits": "^10.0.0"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@commitlint/config-validator": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.1.0.tgz",
-            "integrity": "sha512-gHczt1xqQSwfNqBmOI3HjejtTljkiBEUneExMmTBLD0WwTC78lAqDvNMyydbySt3DhpH0F9oX7Vvuks6s5XPFw==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+            "integrity": "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/types": "^21.2.0",
                 "ajv": "^8.11.0"
             },
             "engines": {
@@ -2728,13 +2745,13 @@
             }
         },
         "node_modules/@commitlint/ensure": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.1.0.tgz",
-            "integrity": "sha512-/S8Mo3Q1NtQUYDQjDmyQVPxfIwtnxq+guzMOkuGk8OSdwlzanm1WB9wDPIuuzlbMDDnBNbiAuBEUCcCNlfjrTQ==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+            "integrity": "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/types": "^21.2.0",
                 "es-toolkit": "^1.46.0"
             },
             "engines": {
@@ -2752,13 +2769,13 @@
             }
         },
         "node_modules/@commitlint/format": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.1.0.tgz",
-            "integrity": "sha512-ySymqKYBfjNrQ5N4W/l1iF2ISW1W7Eu/Oi/wRxlri31N0yjNyzUyUzQwyuZLDzTXIlMs4IZ7hIOfAZx8lO18gA==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
+            "integrity": "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/types": "^21.2.0",
                 "picocolors": "^1.1.1"
             },
             "engines": {
@@ -2766,13 +2783,13 @@
             }
         },
         "node_modules/@commitlint/is-ignored": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.1.0.tgz",
-            "integrity": "sha512-RoRh1/YI+fYH+aid5lMQ2UD0vZ3p3Vf1KeUWT1ir3H/p/7T/6SFv1OiXLgLwUT8dP72EVWeEIyOfkiSWLZYVvw==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
+            "integrity": "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/types": "^21.2.0",
                 "semver": "^7.6.0"
             },
             "engines": {
@@ -2780,32 +2797,32 @@
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.1.0.tgz",
-            "integrity": "sha512-0DbfVVUjAWBfixW6v7CXXWVxMcj6Ukf/oB7O8NAbouP3jxmqUaC4eVQphxl3B3M0ii3cCQiR3sRAYxICwU2gAA==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
+            "integrity": "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/is-ignored": "^21.1.0",
-                "@commitlint/parse": "^21.1.0",
-                "@commitlint/rules": "^21.1.0",
-                "@commitlint/types": "^21.1.0"
+                "@commitlint/is-ignored": "^21.2.0",
+                "@commitlint/parse": "^21.2.0",
+                "@commitlint/rules": "^21.2.0",
+                "@commitlint/types": "^21.2.0"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.1.0.tgz",
-            "integrity": "sha512-juiClVEcoreNB0TNVkseO2EmNcpEs/Yhnmgbnm/hQAKBFRynKwIaoNIljXkx/3yvZcMO0EE8I2XOEI7d5KZG8Q==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
+            "integrity": "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/config-validator": "^21.1.0",
+                "@commitlint/config-validator": "^21.2.0",
                 "@commitlint/execute-rule": "^21.0.1",
-                "@commitlint/resolve-extends": "^21.1.0",
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/resolve-extends": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
                 "cosmiconfig": "^9.0.1",
                 "cosmiconfig-typescript-loader": "^6.1.0",
                 "es-toolkit": "^1.46.0",
@@ -2861,20 +2878,10 @@
                 "typescript": ">=5"
             }
         },
-        "node_modules/@commitlint/load/node_modules/jiti": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "jiti": "lib/jiti-cli.mjs"
-            }
-        },
         "node_modules/@commitlint/message": {
-            "version": "21.0.2",
-            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz",
-            "integrity": "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+            "integrity": "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2882,30 +2889,30 @@
             }
         },
         "node_modules/@commitlint/parse": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.1.0.tgz",
-            "integrity": "sha512-HdAqbbjQS8eEtbR74Ysg2VNmbvAfeWLVYMkip/lHibNrtjRsC/97XAYN3/H5P0pEJtDfyTb3iLs8x6y0eu4OYA==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
+            "integrity": "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/types": "^21.1.0",
-                "conventional-changelog-angular": "^8.2.0",
-                "conventional-commits-parser": "^6.3.0"
+                "@commitlint/types": "^21.2.0",
+                "conventional-changelog-angular": "^9.0.0",
+                "conventional-commits-parser": "^7.0.0"
             },
             "engines": {
                 "node": ">=22.12.0"
             }
         },
         "node_modules/@commitlint/read": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.1.0.tgz",
-            "integrity": "sha512-ID7m79aw8d0dMlxuXHD2QGxEX3Fhl/mUPA80WwEW5VgeOpUHNahhwWJefDdoBDVZcDfbHuf429NrcK0gxQsQjA==",
+            "version": "21.2.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.1.tgz",
+            "integrity": "sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/top-level": "^21.0.2",
-                "@commitlint/types": "^21.1.0",
-                "git-raw-commits": "^5.0.0",
+                "@commitlint/top-level": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
+                "@conventional-changelog/git-client": "^3.0.0",
                 "tinyexec": "^1.0.0"
             },
             "engines": {
@@ -2913,14 +2920,14 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.1.0.tgz",
-            "integrity": "sha512-SANYkxJDfMl3TvnyALWHEaiF5nc6FFaOnh7VvfxjT4X2vD4i2gVHhmfMm1fsrBwDRX98/XyM1XDo5sAd/KXcyQ==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
+            "integrity": "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/config-validator": "^21.1.0",
-                "@commitlint/types": "^21.1.0",
+                "@commitlint/config-validator": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
                 "es-toolkit": "^1.46.0",
                 "global-directory": "^5.0.0",
                 "resolve-from": "^5.0.0"
@@ -2940,16 +2947,16 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.1.0.tgz",
-            "integrity": "sha512-fOPEYSmKn1ZJptjLmCEjJfYqz0PUYr8ng6VY2ZW26sB7KtENR90CmAXHEmScBbOIZip+d/+OwqK12DFBuHTqsQ==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
+            "integrity": "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/ensure": "^21.1.0",
-                "@commitlint/message": "^21.0.2",
+                "@commitlint/ensure": "^21.2.0",
+                "@commitlint/message": "^21.2.0",
                 "@commitlint/to-lines": "^21.0.1",
-                "@commitlint/types": "^21.1.0"
+                "@commitlint/types": "^21.2.0"
             },
             "engines": {
                 "node": ">=22.12.0"
@@ -2966,9 +2973,9 @@
             }
         },
         "node_modules/@commitlint/top-level": {
-            "version": "21.0.2",
-            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz",
-            "integrity": "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+            "integrity": "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2979,12 +2986,12 @@
             }
         },
         "node_modules/@commitlint/types": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.1.0.tgz",
-            "integrity": "sha512-YodnnnH1Cp+08nP8HGNJAIuB6L3/vdCTHVRTfF8Ik/wRCLOTsU9zwv3yO1cSPQRDa9CLYtE+UJ2K67r7CwMSFw==",
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+            "integrity": "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==",
             "license": "MIT",
             "dependencies": {
-                "conventional-commits-parser": "^6.3.0",
+                "conventional-commits-parser": "^7.0.0",
                 "picocolors": "^1.1.1"
             },
             "engines": {
@@ -2992,22 +2999,22 @@
             }
         },
         "node_modules/@conventional-changelog/git-client": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
-            "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
+            "integrity": "sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@simple-libs/child-process-utils": "^1.0.0",
-                "@simple-libs/stream-utils": "^1.2.0",
+                "@simple-libs/child-process-utils": "^2.0.0",
+                "@simple-libs/stream-utils": "^2.0.0",
                 "semver": "^7.5.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
-                "conventional-commits-filter": "^5.0.0",
-                "conventional-commits-parser": "^6.4.0"
+                "conventional-commits-filter": "^6.0.1",
+                "conventional-commits-parser": "^7.0.1"
             },
             "peerDependenciesMeta": {
                 "conventional-commits-filter": {
@@ -3016,6 +3023,15 @@
                 "conventional-commits-parser": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@conventional-changelog/template": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+            "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@cspell/cspell-bundled-dicts": {
@@ -4421,9 +4437,9 @@
             "peer": true
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4531,9 +4547,9 @@
             "peer": true
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -5212,9 +5228,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -5550,9 +5566,9 @@
             "peer": true
         },
         "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -6052,9 +6068,9 @@
             "license": "MIT"
         },
         "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6717,25 +6733,25 @@
             }
         },
         "node_modules/@release-it/conventional-changelog": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.1.tgz",
-            "integrity": "sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-12.0.0.tgz",
+            "integrity": "sha512-b9N8/tUjO9JNH1u2fVSmq8QmbqnE//Y5iCgvPcytsk0pj0GhgGCp+VmfzhEBIdd+lVGZJKs+ZSaGaOHjtmtv7g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@conventional-changelog/git-client": "^2.7.0",
+                "@conventional-changelog/git-client": "^3.1.0",
                 "concat-stream": "^2.0.0",
-                "conventional-changelog": "^7.2.0",
-                "conventional-changelog-angular": "^8.3.1",
-                "conventional-changelog-conventionalcommits": "^9.3.1",
-                "conventional-recommended-bump": "^11.2.0",
-                "semver": "^7.7.4"
+                "conventional-changelog": "^8.1.0",
+                "conventional-changelog-angular": "^9.2.1",
+                "conventional-changelog-conventionalcommits": "^10.2.1",
+                "conventional-recommended-bump": "^12.1.0",
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+                "node": "^22.21.0 || >=24.0.0"
             },
             "peerDependencies": {
-                "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0"
+                "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
             }
         },
         "node_modules/@release-it/conventional-changelog/node_modules/semver": {
@@ -7415,41 +7431,71 @@
             }
         },
         "node_modules/@simple-libs/child-process-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
-            "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+            "integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@simple-libs/stream-utils": "^1.2.0"
+                "@simple-libs/stream-utils": "^2.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://ko-fi.com/dangreen"
             }
         },
         "node_modules/@simple-libs/hosted-git-info": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
-            "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-2.0.0.tgz",
+            "integrity": "sha512-55XwK/GYgV58PuN8lZFhI1qRxdKoMLJocXl/yM1EPqazFDmM4QWY7q6BxPCPDNKTNunj794DSD4h0H7SrqUdMg==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://ko-fi.com/dangreen"
             }
         },
+        "node_modules/@simple-libs/normalize-package-data": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/normalize-package-data/-/normalize-package-data-1.0.0.tgz",
+            "integrity": "sha512-/EOmFBekV9tGee8gac/k+5Ox3twkypNqh5TfxA9vTkmcJkjm6f1xqrlstDNOrEhTvnYyVtU6Du2ZhY/IV1+9GA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@simple-libs/hosted-git-info": "^2.0.0",
+                "semver": "^7.8.5"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
+        "node_modules/@simple-libs/normalize-package-data/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@simple-libs/stream-utils": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
-            "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+            "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://ko-fi.com/dangreen"
@@ -7678,9 +7724,9 @@
             "license": "MIT"
         },
         "node_modules/@tufjs/models/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7906,13 +7952,6 @@
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
-        },
-        "node_modules/@types/normalize-package-data": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@types/parse-author": {
             "version": "2.0.3",
@@ -8575,6 +8614,18 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
+        "node_modules/argue-cli": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+            "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
         "node_modules/aria-query": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -8608,12 +8659,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/array-ify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-            "license": "MIT"
         },
         "node_modules/array-includes": {
             "version": "3.1.9",
@@ -9149,12 +9194,12 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+            "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
             "license": "MIT",
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/base64-js": {
@@ -9497,9 +9542,9 @@
             "license": "MIT"
         },
         "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9579,9 +9624,9 @@
             }
         },
         "node_modules/cacache/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -9606,14 +9651,14 @@
             }
         },
         "node_modules/cacheable": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
-            "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+            "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@cacheable/memory": "^2.0.8",
-                "@cacheable/utils": "^2.4.1",
+                "@cacheable/memory": "^2.2.0",
+                "@cacheable/utils": "^2.5.0",
                 "hookified": "^1.15.0",
                 "keyv": "^5.6.0",
                 "qified": "^0.10.1"
@@ -10119,16 +10164,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/compare-func": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-            "license": "MIT",
-            "dependencies": {
-                "array-ify": "^1.0.0",
-                "dot-prop": "^5.1.0"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -10217,128 +10252,127 @@
             }
         },
         "node_modules/conventional-changelog": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.1.tgz",
-            "integrity": "sha512-smcpqCeNRCAoL586/Iql8GfVsduP1JDrr7SAzKHWM5C5voDzKhc3QtqwVWeKMhvVw4iYfAr+znz1TF4kPXVm3A==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-8.1.0.tgz",
+            "integrity": "sha512-idt1JK+3+Nt7gqH/d/sEYWdDeR+5XPov/jssmFN6XxmYSRlonTWSDWhWUPkmm0zbwYjtVdt+4My5aiPkKyvocw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@conventional-changelog/git-client": "^2.7.0",
-                "@simple-libs/hosted-git-info": "^1.0.2",
-                "@types/normalize-package-data": "^2.4.4",
-                "conventional-changelog-preset-loader": "^5.0.0",
-                "conventional-changelog-writer": "^8.4.0",
-                "conventional-commits-parser": "^6.4.0",
-                "fd-package-json": "^2.0.0",
-                "meow": "^13.0.0",
-                "normalize-package-data": "^7.0.0"
+                "@conventional-changelog/git-client": "^3.1.0",
+                "@simple-libs/hosted-git-info": "^2.0.0",
+                "@simple-libs/normalize-package-data": "^1.0.0",
+                "argue-cli": "^3.1.0",
+                "conventional-changelog-preset-loader": "^6.0.1",
+                "conventional-changelog-writer": "^9.2.0",
+                "conventional-commits-parser": "^7.1.0",
+                "fd-package-json": "^2.0.0"
             },
             "bin": {
                 "conventional-changelog": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-changelog-angular": {
-            "version": "8.3.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
-            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+            "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
             "license": "ISC",
             "peer": true,
             "dependencies": {
-                "compare-func": "^2.0.0"
+                "@conventional-changelog/template": "^1.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-            "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+            "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
             "license": "ISC",
             "dependencies": {
-                "compare-func": "^2.0.0"
+                "@conventional-changelog/template": "^1.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-changelog-preset-loader": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
-            "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-6.0.1.tgz",
+            "integrity": "sha512-GZ8E3RQzXQb3JFy0pKl8oeSf7ENIhvAMvJr+PlWkavZOesLHHdhkfNJ4SvW35eo1Fu2+EyVxWQ1tVvtzAG2iWg==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-changelog-writer": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
-            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-9.2.0.tgz",
+            "integrity": "sha512-eACD5BaAQCYjeI3RExkCZopNaaIuXzCP4kaAb2lEFXcGa/KOuxJfj8v/SnjhvF6377pYn0A2Gji+6GhwUK8rEA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@simple-libs/stream-utils": "^1.2.0",
-                "conventional-commits-filter": "^5.0.0",
-                "handlebars": "^4.7.7",
-                "meow": "^13.0.0",
+                "@conventional-changelog/template": "^1.2.1",
+                "@simple-libs/stream-utils": "^2.0.0",
+                "argue-cli": "^3.1.0",
+                "conventional-commits-filter": "^6.0.1",
                 "semver": "^7.5.2"
             },
             "bin": {
                 "conventional-changelog-writer": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-commits-filter": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+            "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-commits-parser": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.1.tgz",
+            "integrity": "sha512-B0f42jI++V5Vb7qK+DDw68r0dNxz5hk+RdKUkx2NOi39emc9hsHa3u2M3doF7QQhRFzCrAj7uM90teG+RBTaYQ==",
             "license": "MIT",
             "dependencies": {
-                "@simple-libs/stream-utils": "^1.2.0",
-                "meow": "^13.0.0"
+                "@simple-libs/stream-utils": "^2.0.0",
+                "argue-cli": "^3.1.0"
             },
             "bin": {
                 "conventional-commits-parser": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/conventional-recommended-bump": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-11.2.0.tgz",
-            "integrity": "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-12.1.0.tgz",
+            "integrity": "sha512-HTNG3kEZXOOfKwrEx54ljURU9bG4nVPQzXMyCSeUcA/PE8EpNpQNujSrbXNBI8QZyN35zM+pVw+FuQk4KqHSHg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@conventional-changelog/git-client": "^2.5.1",
-                "conventional-changelog-preset-loader": "^5.0.0",
-                "conventional-commits-filter": "^5.0.0",
-                "conventional-commits-parser": "^6.1.0",
-                "meow": "^13.0.0"
+                "@conventional-changelog/git-client": "^3.1.0",
+                "argue-cli": "^3.1.0",
+                "conventional-changelog-preset-loader": "^6.0.1",
+                "conventional-commits-filter": "^6.0.1",
+                "conventional-commits-parser": "^7.1.0"
             },
             "bin": {
                 "conventional-recommended-bump": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/convert-source-map": {
@@ -11287,18 +11321,6 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/dot-prop": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-            "license": "MIT",
-            "dependencies": {
-                "is-obj": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/dotenv": {
             "version": "16.4.7",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -11693,14 +11715,15 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.48.1",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
-            "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
             "license": "MIT",
             "peer": true,
             "workspaces": [
                 "docs",
-                "benchmarks"
+                "benchmarks",
+                "tests/types"
             ]
         },
         "node_modules/esbuild": {
@@ -12145,9 +12168,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -12565,9 +12588,9 @@
             "peer": true
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -13611,24 +13634,6 @@
                 "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
         },
-        "node_modules/git-raw-commits": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
-            "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
-            "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@conventional-changelog/git-client": "^2.6.0",
-                "meow": "^13.0.0"
-            },
-            "bin": {
-                "git-raw-commits": "src/cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/git-up": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
@@ -13698,9 +13703,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14034,6 +14039,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
             "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
@@ -14046,6 +14052,7 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/html-encoding-sniffer": {
@@ -14145,9 +14152,9 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -14224,9 +14231,9 @@
             "license": "MIT"
         },
         "node_modules/ignore-walk/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14502,9 +14509,9 @@
             }
         },
         "node_modules/is-builtin-module/node_modules/builtin-modules": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
-            "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+            "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.20"
@@ -14791,15 +14798,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-obj": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-path-inside": {
@@ -15346,9 +15344,9 @@
             "peer": true
         },
         "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -15804,9 +15802,9 @@
             "peer": true
         },
         "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -16051,9 +16049,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "license": "MIT",
             "peer": true,
             "bin": {
@@ -16077,9 +16075,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "funding": [
                 {
                     "type": "github",
@@ -16523,9 +16521,9 @@
             }
         },
         "node_modules/lint-staged/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -17195,18 +17193,6 @@
             "peer": true,
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/meow": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/merge-descriptors": {
@@ -18129,9 +18115,9 @@
             "license": "MIT"
         },
         "node_modules/multimatch/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -18334,9 +18320,9 @@
             }
         },
         "node_modules/node-gyp/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -18403,21 +18389,6 @@
             },
             "bin": {
                 "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/normalize-package-data": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
-            "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "hosted-git-info": "^8.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
@@ -18700,16 +18671,6 @@
                 "@swc/core": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/nx/node_modules/balanced-match": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-            "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "20 || >=22"
             }
         },
         "node_modules/nx/node_modules/cli-cursor": {
@@ -19308,9 +19269,9 @@
             }
         },
         "node_modules/package-json-validator/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -19638,9 +19599,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -20074,9 +20035,9 @@
             "peer": true
         },
         "node_modules/prettier-package-json/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -21237,9 +21198,9 @@
             }
         },
         "node_modules/release-it/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -22743,23 +22704,23 @@
             }
         },
         "node_modules/stylelint/node_modules/file-entry-cache": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
-            "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+            "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "flat-cache": "^6.1.22"
+                "flat-cache": "^6.1.23"
             }
         },
         "node_modules/stylelint/node_modules/flat-cache": {
-            "version": "6.1.22",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
-            "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+            "version": "6.1.23",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+            "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "cacheable": "^2.3.4",
+                "cacheable": "^2.5.0",
                 "flatted": "^3.4.2",
                 "hookified": "^1.15.0"
             }
@@ -22778,9 +22739,9 @@
             }
         },
         "node_modules/stylelint/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -23104,9 +23065,9 @@
             "peer": true
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -24634,11 +24595,10 @@
             "version": "0.554.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@commitlint/config-conventional": "21.1.0",
-                "conventional-changelog-conventionalcommits": "9.3.1"
+                "@commitlint/config-conventional": "21.2.0"
             },
             "peerDependencies": {
-                "@commitlint/cli": "^21.1.0",
+                "@commitlint/cli": "^21.2.0",
                 "lint-staged": "^17.0.8"
             }
         },
@@ -24647,17 +24607,17 @@
             "version": "0.554.0",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@taiga-ui/auto-changelog-config": "^0.550.0",
-                "@taiga-ui/browserslist-config": "^0.550.0",
-                "@taiga-ui/commitlint-config": "^0.550.0",
-                "@taiga-ui/cspell-config": "^0.550.0",
-                "@taiga-ui/eslint-plugin-experience-next": "^0.550.0",
-                "@taiga-ui/jest-config": "^0.550.0",
-                "@taiga-ui/prettier-config": "^0.550.0",
-                "@taiga-ui/release-it-config": "^0.550.0",
-                "@taiga-ui/stylelint-config": "^0.550.0",
-                "@taiga-ui/syncer": "^0.550.0",
-                "@taiga-ui/tsconfig": "^0.550.0"
+                "@taiga-ui/auto-changelog-config": "^0.554.0",
+                "@taiga-ui/browserslist-config": "^0.554.0",
+                "@taiga-ui/commitlint-config": "^0.554.0",
+                "@taiga-ui/cspell-config": "^0.554.0",
+                "@taiga-ui/eslint-plugin-experience-next": "^0.554.0",
+                "@taiga-ui/jest-config": "^0.554.0",
+                "@taiga-ui/prettier-config": "^0.554.0",
+                "@taiga-ui/release-it-config": "^0.554.0",
+                "@taiga-ui/stylelint-config": "^0.554.0",
+                "@taiga-ui/syncer": "^0.554.0",
+                "@taiga-ui/tsconfig": "^0.554.0"
             }
         },
         "projects/cspell-config": {
@@ -24720,12 +24680,12 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/@angular-devkit/architect": {
-            "version": "0.2200.4",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.4.tgz",
-            "integrity": "sha512-X/iEQiZ0pRmpjUt11jCM+mtOLRl4XxI9hnM0IC9aAcsm5AzRBb9WY6QIEqOSficjxC/+MI7MGwrerrcP6QN8UA==",
+            "version": "0.2200.9",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.9.tgz",
+            "integrity": "sha512-kwiyEFfJsnJ4o7ondW8KswwJbp+qri5yWLS0wMMG+uBwOolZfrQReorqsQNCALhwmojhDNZc0wEWXEHEhKnotw==",
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "22.0.4",
+                "@angular-devkit/core": "22.0.9",
                 "rxjs": "7.8.2"
             },
             "bin": {
@@ -24738,9 +24698,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/@angular-devkit/core": {
-            "version": "22.0.4",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.4.tgz",
-            "integrity": "sha512-zA2UJSMAU3su5uJTOn5ul/gCLRcw6/uIQ6EC5v/Ju/ePjgDIw9R3y3MAvWQ4Ibi/fXiq0FVxpF8hE7RUclYmJA==",
+            "version": "22.0.9",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.9.tgz",
+            "integrity": "sha512-u53kltrh1ZKHSqGfEDbPW2RzSC1WBPpan3LN61TuzjAkiHqqaQXrN6EmUvYkX3CIT5PKhO6RPRsptMH9y7hs0w==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "8.20.0",
@@ -24765,12 +24725,12 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/@angular-devkit/schematics": {
-            "version": "22.0.4",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.4.tgz",
-            "integrity": "sha512-VRxL1hD/Q3TQglM6EfQ0ksAW4OIvtKyZgtaUpyGsJRfD6tGmLFn7MDnmyyq1ceLX/Clq+3tzH/wN0tF6rcE0jA==",
+            "version": "22.0.9",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.9.tgz",
+            "integrity": "sha512-r7tPuiXI7pnwcaLQY4hQLOM9R5rkKRc1mKhQQb074Shh8XzTcTaw2ktDXLeiJm/SUUWQPhaxClnjjO3qU8AJRw==",
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "22.0.4",
+                "@angular-devkit/core": "22.0.9",
                 "jsonc-parser": "3.3.1",
                 "magic-string": "0.30.21",
                 "ora": "9.4.0",
@@ -24828,19 +24788,19 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/@angular/cli": {
-            "version": "22.0.4",
-            "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.4.tgz",
-            "integrity": "sha512-3eJy6VoNlgskKFzvqy3AJsYXFRhSBLLGObF2iTpJymsukuxWUen7hlVVVWrO5++bW1LEgd6PTCCD5fdT2UuRiA==",
+            "version": "22.0.9",
+            "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.9.tgz",
+            "integrity": "sha512-nkdz9sc9OjTLBG2QwPH8HuFc4fOl489AzrKInM2y+Q0u1+/HFt9QpSeupPnDJeOYGImDIP0B2VJJ3teDRM1DGg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@angular-devkit/architect": "0.2200.4",
-                "@angular-devkit/core": "22.0.4",
-                "@angular-devkit/schematics": "22.0.4",
+                "@angular-devkit/architect": "0.2200.9",
+                "@angular-devkit/core": "22.0.9",
+                "@angular-devkit/schematics": "22.0.9",
                 "@inquirer/prompts": "8.4.2",
                 "@listr2/prompt-adapter-inquirer": "4.2.3",
                 "@modelcontextprotocol/sdk": "1.29.0",
-                "@schematics/angular": "22.0.4",
+                "@schematics/angular": "22.0.9",
                 "@yarnpkg/lockfile": "1.1.0",
                 "algoliasearch": "5.52.0",
                 "ini": "6.0.0",
@@ -25360,14 +25320,14 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/@schematics/angular": {
-            "version": "22.0.4",
-            "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.4.tgz",
-            "integrity": "sha512-P3V3tkqIR+n0GJSv0ibf34/zMtKbFp6kaTjBe5cm/RyXuHbmdaPYjk8PNphkGMypDtWCof1RtNnW/hl832Wnew==",
+            "version": "22.0.9",
+            "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.9.tgz",
+            "integrity": "sha512-moQI3UnqUt6GZ81ykxJRUbf+IpM6SDFRyMMj6A2VNSiUGVpSAETNFIuTk/6YDzNG8yhMN9zOICeBwvvPH0ylbA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@angular-devkit/core": "22.0.4",
-                "@angular-devkit/schematics": "22.0.4",
+                "@angular-devkit/core": "22.0.9",
+                "@angular-devkit/schematics": "22.0.9",
                 "jsonc-parser": "3.3.1",
                 "typescript": "6.0.3"
             },
@@ -25567,22 +25527,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "projects/eslint-plugin-experience-next/node_modules/chokidar": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
         "projects/eslint-plugin-experience-next/node_modules/chownr": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -25623,9 +25567,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/cli-truncate/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -25820,9 +25764,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "license": "BlueOak-1.0.0",
             "peer": true,
             "engines": {
@@ -26069,9 +26013,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/ora/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "dependencies": {
                 "get-east-asian-width": "^1.5.0",
@@ -26124,20 +26068,6 @@
             "peer": true,
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "projects/eslint-plugin-experience-next/node_modules/readdirp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20.19.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/semver": {
@@ -26222,9 +26152,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "license": "BlueOak-1.0.0",
             "peer": true,
             "dependencies": {
@@ -26268,9 +26198,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/undici": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -26322,9 +26252,9 @@
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -26407,8 +26337,8 @@
             "version": "0.554.0",
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@release-it/conventional-changelog": "^11.0.1",
-                "@taiga-ui/auto-changelog-config": "^0.550.0",
+                "@release-it/conventional-changelog": "^12.0.0",
+                "@taiga-ui/auto-changelog-config": "^0.554.0",
                 "release-it": "^20.2.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,6 +2654,22 @@
                 "node": ">=20"
             }
         },
+        "node_modules/@commitlint/cli/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -2833,51 +2849,6 @@
                 "node": ">=22.12.0"
             }
         },
-        "node_modules/@commitlint/load/node_modules/cosmiconfig": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "env-paths": "^2.2.1",
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@commitlint/load/node_modules/cosmiconfig-typescript-loader": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
-            "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "jiti": "2.6.1"
-            },
-            "engines": {
-                "node": ">=v18"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "cosmiconfig": ">=9",
-                "typescript": ">=5"
-            }
-        },
         "node_modules/@commitlint/message": {
             "version": "21.2.0",
             "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
@@ -2934,16 +2905,6 @@
             },
             "engines": {
                 "node": ">=22.12.0"
-            }
-        },
-        "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@commitlint/rules": {
@@ -3223,9 +3184,9 @@
             }
         },
         "node_modules/@cspell/dict-companies": {
-            "version": "3.2.11",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.11.tgz",
-            "integrity": "sha512-0cmafbcz2pTHXLd59eLR1gvDvN6aWAOM0+cIL4LLF9GX9yB2iKDNrKsvs4tJRqutoaTdwNFBbV0FYv+6iCtebQ==",
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.12.tgz",
+            "integrity": "sha512-mjiz/N3zWOCsz5VfwMUydSl7uW0OU9H2PnbCNc3RV44Vj6Q59CSp6EYGSGZQxrXU1gpsuZUrwr6QCjNjFOOg5A==",
             "license": "MIT",
             "peer": true
         },
@@ -3265,9 +3226,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-data-science": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.14.tgz",
-            "integrity": "sha512-jl6Ds4u5u5JT+yY30pWQpAbdCHfy3lCcNkLbpL/AZKoUaLEoXbaYsps9xQtvD7DyaiXxiLZkdH2yHHXtoFtZyg==",
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.16.tgz",
+            "integrity": "sha512-M72mxv5asuAnORurz4iXRJ+Tw9XBq6eu7D2Ne7biP0Z1RciKGNxXWu9JycA/KlVvK1hAlKj/fANlXhuEWpXKFg==",
             "license": "MIT",
             "peer": true
         },
@@ -3300,30 +3261,30 @@
             "peer": true
         },
         "node_modules/@cspell/dict-en_us": {
-            "version": "4.4.35",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.35.tgz",
-            "integrity": "sha512-xWpxBCc/FzzMMo/A+0qwARVaIIhR0Ql8yhhv4rvsvg+GfQF+LG9yzg2GwTM5N2rjvzmM3nKuR9zxFZq2I6fJSg==",
+            "version": "4.4.36",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.36.tgz",
+            "integrity": "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/@cspell/dict-en-common-misspellings": {
-            "version": "2.1.12",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.12.tgz",
-            "integrity": "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw==",
+            "version": "2.1.13",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.13.tgz",
+            "integrity": "sha512-00rpydUxKNWY2xxrSx+h46aNWLvbkJdd57SsnEFt24fbs1fROhXZ6XSQu+gQz/zNuiCvFi4Ro3ej9DLbEdWQmQ==",
             "license": "CC BY-SA 4.0",
             "peer": true
         },
         "node_modules/@cspell/dict-en-gb": {
-            "version": "5.0.29",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-5.0.29.tgz",
-            "integrity": "sha512-r9gISbSufiJ1AVluQ2qROX6dBqF0sMSvOPWKKYsBKaaw5aBh0zy4+a6oVuXdaCgv7s79oizjHHc2BhiVaZ6nyw==",
+            "version": "5.0.30",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-5.0.30.tgz",
+            "integrity": "sha512-WYpGgnCzoghOkr0Q3MB56D0nAxG05caDghU+3POpA5ZTP+5DKjxUrImtdcdE1ekcL1fgI1GaHsKNe8kwTVWK5Q==",
             "license": "LGPL-3.0",
             "peer": true
         },
         "node_modules/@cspell/dict-en-gb-mit": {
-            "version": "3.1.24",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.24.tgz",
-            "integrity": "sha512-Oowb/Uzkh7OmDRdCcETzMc9imEb4IpLlHJXoYjX8A8DS2X/54gqSjI915JFB8hKtFjBko5OM0BLQ+6cZhFEMmQ==",
+            "version": "3.1.25",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.25.tgz",
+            "integrity": "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg==",
             "license": "MIT",
             "peer": true
         },
@@ -3433,9 +3394,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-k8s": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.12.tgz",
-            "integrity": "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.13.tgz",
+            "integrity": "sha512-ELGkS13k7K/NEfVimBSrxVTfqXvOF/Kvxj4I62YxRm8bvHbfoXgrGaOx28lPiNRz+dmu+yYtvuXbnURKtYbC6g==",
             "license": "MIT",
             "peer": true
         },
@@ -3509,9 +3470,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-npm": {
-            "version": "5.2.41",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.41.tgz",
-            "integrity": "sha512-To3xsfRmMBYVXtWVEdUgV35M9a/JZ54dSuoY6m6D3uHKKL3I326Wmy4xifZ3PU8MQaWhyEH7zbIcUEtKwTQMcA==",
+            "version": "5.2.43",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.43.tgz",
+            "integrity": "sha512-H2gYwtu59dNO9662Uq0usfuhyNd7lZJE1C61a/UXcpRyWWSrTo2Bz+vwGYp1bXZ1LmjXadqvwJ8ArFlGdiadNQ==",
             "license": "MIT",
             "peer": true
         },
@@ -3537,13 +3498,13 @@
             "peer": true
         },
         "node_modules/@cspell/dict-python": {
-            "version": "4.2.27",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.27.tgz",
-            "integrity": "sha512-Rj6xQgYS4X6ienjgAZF+njA0GRY4oSPouJWv0vfikCTn6EWlfk0V6Dy1HP3Migj1O+IC2NmespgVq+BZNSp8OA==",
+            "version": "4.2.29",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.29.tgz",
+            "integrity": "sha512-OnEt1a35iuQzc2Ize1qU/43ZyF10urRKAm+mlTz++vnAgDLBHpKfWakpSK50nyL5/1WvyQ8BaMjb52MBLEpTeA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@cspell/dict-data-science": "^2.0.14"
+                "@cspell/dict-data-science": "^2.0.16"
             }
         },
         "node_modules/@cspell/dict-r": {
@@ -3604,9 +3565,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-software-terms": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.2.tgz",
-            "integrity": "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.4.tgz",
+            "integrity": "sha512-z6y/TGH3QNf5wB4pVvN/P3GfFEW/Whf6QAekNsIn06VKl95dnamfpkPWqV8rEtCixQFaKalb5+y9hRQXH3XQ1g==",
             "license": "MIT",
             "peer": true
         },
@@ -3632,9 +3593,9 @@
             "peer": true
         },
         "node_modules/@cspell/dict-terraform": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.3.tgz",
-            "integrity": "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.1.4.tgz",
+            "integrity": "sha512-Ere42ilvMFvQA4GlcN0OKlruMPR6EsvaB+iTHzj2xc+NJGRK64V7yApUcWrOrSgTiM/vhWXPIsK3OMfiAiNdmA==",
             "license": "MIT",
             "peer": true
         },
@@ -3738,9 +3699,9 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
             "funding": [
                 {
                     "type": "github",
@@ -3784,9 +3745,9 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-            "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
             "funding": [
                 {
                     "type": "github",
@@ -3851,9 +3812,9 @@
             }
         },
         "node_modules/@csstools/selector-resolve-nested": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
-            "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+            "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
             "funding": [
                 {
                     "type": "github",
@@ -4376,9 +4337,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+            "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -4499,9 +4460,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4511,7 +4472,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -4570,16 +4531,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 4"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4601,9 +4552,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4672,9 +4623,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "1.19.17",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+            "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -5156,6 +5107,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -5283,16 +5250,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -5319,6 +5276,23 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/console/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/@jest/core": {
@@ -5369,20 +5343,21 @@
                 }
             }
         },
-        "node_modules/@jest/core/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+        "node_modules/@jest/core/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "type-fest": "^0.21.3"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/@jest/core/node_modules/ci-info": {
@@ -5399,32 +5374,6 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@jest/core/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/core/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "license": "(MIT OR CC0-1.0)",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@jest/diff-sequences": {
@@ -5576,6 +5525,23 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/@jest/reporters/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/@jest/reporters/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5609,19 +5575,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@jest/schemas": {
@@ -5711,6 +5664,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@jest/transform/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/@jest/transform/node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5734,6 +5704,23 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/types/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -5939,6 +5926,44 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
@@ -6483,6 +6508,54 @@
                 }
             }
         },
+        "node_modules/@nx/rollup/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@nx/rollup/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@nx/rollup/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@nx/rollup/node_modules/source-map-support": {
+            "version": "0.5.19",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
         "node_modules/@nx/workspace": {
             "version": "23.0.1",
             "resolved": "https://registry.npmjs.org/@nx/workspace/-/workspace-23.0.1.tgz",
@@ -6499,6 +6572,23 @@
                 "semver": "^7.6.3",
                 "tslib": "^2.3.0",
                 "yargs-parser": "21.1.1"
+            }
+        },
+        "node_modules/@nx/workspace/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/@octokit/auth-token": {
@@ -6612,9 +6702,9 @@
             }
         },
         "node_modules/@octokit/request": {
-            "version": "10.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-            "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+            "version": "10.0.11",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+            "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -6818,6 +6908,57 @@
                 "rollup": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@rollup/plugin-image": {
@@ -7502,9 +7643,9 @@
             }
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "version": "0.27.12",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+            "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
             "license": "MIT",
             "peer": true
         },
@@ -7846,9 +7987,9 @@
             }
         },
         "node_modules/@types/hast": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -7944,9 +8085,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.0.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-            "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -8045,6 +8186,51 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/@typescript-eslint/parser": {
             "version": "8.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
@@ -8067,6 +8253,19 @@
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
@@ -8104,6 +8303,44 @@
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "4.6.2",
                 "semver": "^7.7.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8171,6 +8408,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/tsconfig-utils": {
             "version": "8.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
@@ -8211,10 +8461,46 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/types": {
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
             "version": "8.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
             "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8251,6 +8537,19 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -8264,15 +8563,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
-            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0"
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8286,6 +8585,128 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.65.0",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "8.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
@@ -8295,6 +8716,19 @@
                 "@typescript-eslint/types": "8.62.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -8404,9 +8838,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -8458,12 +8892,16 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "debug": "4"
+            },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/ajv": {
@@ -8536,27 +8974,31 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
-            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "environment": "^1.0.0"
+                "type-fest": "^0.21.3"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
@@ -8902,9 +9344,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.2",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-            "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+            "version": "10.5.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
             "dev": true,
             "funding": [
                 {
@@ -8922,8 +9364,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.4",
-                "caniuse-lite": "^1.0.30001799",
+                "browserslist": "^4.28.6",
+                "caniuse-lite": "^1.0.30001806",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -8994,6 +9436,23 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.8.0"
+            }
+        },
+        "node_modules/babel-jest/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/babel-plugin-const-enum": {
@@ -9085,6 +9544,33 @@
             "engines": {
                 "node": ">=10",
                 "npm": ">=6"
+            }
+        },
+        "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/babel-plugin-macros/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "devOptional": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -9194,12 +9680,12 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
-            "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "license": "MIT",
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/base64-js": {
@@ -9224,9 +9710,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.38",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.6.tgz",
+            "integrity": "sha512-69D/imtToCsIcAl8WBS2YaRwA4jO/j0HhU+hELqMEu9f54MoUtI6+XH5mrKU8rEFNEk/Ui1I2MK4/JkWacclGw==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -9290,15 +9776,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -9315,9 +9801,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9334,10 +9820,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.38",
-                "caniuse-lite": "^1.0.30001799",
-                "electron-to-chromium": "^1.5.376",
-                "node-releases": "^2.0.48",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -9741,9 +10227,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9771,16 +10257,12 @@
             }
         },
         "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -9800,19 +10282,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk-template?sponsor=1"
-            }
-        },
-        "node_modules/chalk-template/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/change-case": {
@@ -9996,18 +10465,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cliui/node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -10097,19 +10554,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/columnify/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/combined-stream": {
@@ -10439,28 +10883,48 @@
             }
         },
         "node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/cosmiconfig/node_modules/yaml": {
-            "version": "1.10.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-            "license": "ISC",
+        "node_modules/cosmiconfig-typescript-loader": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+            "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "jiti": "2.6.1"
+            },
             "engines": {
-                "node": ">= 6"
+                "node": ">=v18"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "cosmiconfig": ">=9",
+                "typescript": ">=5"
             }
         },
         "node_modules/create-jest": {
@@ -10485,6 +10949,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/create-jest/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/create-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -10501,21 +10982,6 @@
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/cross-spawn/node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
             },
             "engines": {
                 "node": ">= 8"
@@ -10721,16 +11187,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/cspell-lib/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cspell-trie-lib": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.1.tgz",
@@ -10742,32 +11198,6 @@
             },
             "peerDependencies": {
                 "@cspell/cspell-types": "10.0.1"
-            }
-        },
-        "node_modules/cspell/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/cspell/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/cspell/node_modules/commander": {
@@ -11404,9 +11834,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.378",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
-            "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+            "version": "1.5.398",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+            "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
             "license": "ISC"
         },
         "node_modules/ember-rfc176-data": {
@@ -11626,18 +12056,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-abstract-get/node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -11657,9 +12075,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -11696,12 +12114,13 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
-            "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+            "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
             "license": "MIT",
             "dependencies": {
                 "es-abstract-get": "^1.0.0",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
                 "is-date-object": "^1.1.0",
@@ -11799,13 +12218,16 @@
             "peer": true
         },
         "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=0.8.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/escodegen": {
@@ -11842,9 +12264,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -11853,8 +12275,8 @@
                 "@eslint/config-array": "^0.21.2",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -11917,9 +12339,9 @@
             }
         },
         "node_modules/eslint-fix-utils": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.2.tgz",
-            "integrity": "sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.3.tgz",
+            "integrity": "sha512-EKzNhsNavV5DdkHVltHBM9TqfsonCmiUhOm1Ra97zo03M9IAx3wtM1eC27eWGMj/D3LrALmHHNe1QlQH1P7Nxw==",
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -11999,9 +12421,9 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-            "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+            "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^3.2.7"
@@ -12186,18 +12608,6 @@
                 "ms": "^2.1.1"
             }
         },
-        "node_modules/eslint-plugin-import/node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
         "node_modules/eslint-plugin-import/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -12217,18 +12627,6 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/json5": "^0.0.29",
-                "json5": "^1.0.2",
-                "minimist": "^1.2.6",
-                "strip-bom": "^3.0.0"
             }
         },
         "node_modules/eslint-plugin-jest": {
@@ -12598,27 +12996,21 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/eslint/node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+        "node_modules/eslint/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "license": "MIT",
             "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
             "engines": {
                 "node": ">=10"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/eslint/node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 4"
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -12881,12 +13273,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-            "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+            "version": "8.6.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+            "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
+                "debug": "^4.4.3",
                 "ip-address": "^10.2.0"
             },
             "engines": {
@@ -12937,9 +13330,9 @@
             }
         },
         "node_modules/exsolve": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
             "license": "MIT",
             "peer": true
         },
@@ -12956,9 +13349,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/fast-equals": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
-            "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
+            "integrity": "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -13026,9 +13419,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -13137,6 +13530,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/figures/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -13238,9 +13641,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "license": "ISC",
             "peer": true
         },
@@ -13662,21 +14065,17 @@
             "license": "ISC"
         },
         "node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": ">=12"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -13693,36 +14092,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-            "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/global-directory": {
@@ -13828,9 +14197,9 @@
             }
         },
         "node_modules/globby": {
-            "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-            "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+            "version": "16.2.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+            "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -13846,6 +14215,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globby/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/globby/node_modules/slash": {
@@ -14019,9 +14398,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.27",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-            "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+            "version": "4.12.32",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+            "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -14116,29 +14495,32 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
+                "@tootallnate/once": "2",
+                "agent-base": "6",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/human-signals": {
@@ -14202,10 +14584,11 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -14285,6 +14668,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/import-from": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
@@ -14294,16 +14686,6 @@
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-from/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -14402,9 +14784,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -15256,6 +15638,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-circus/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-cli": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
@@ -15288,6 +15687,23 @@
                 "node-notifier": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/jest-cli/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-config": {
@@ -15352,6 +15768,23 @@
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/jest-config/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-config/node_modules/ci-info": {
@@ -15421,6 +15854,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-diff/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-docblock": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
@@ -15459,6 +15909,23 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-each/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-environment-jsdom": {
@@ -15573,6 +16040,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-matcher-utils/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -15592,6 +16076,23 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-mock": {
@@ -15706,6 +16207,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-resolve/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-runner": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
@@ -15739,25 +16257,21 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-runner/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/source-map-support": {
-            "version": "0.5.13",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+        "node_modules/jest-runner/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-runtime": {
@@ -15812,6 +16326,23 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/jest-runtime/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-runtime/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -15847,16 +16378,6 @@
                 "node": "*"
             }
         },
-        "node_modules/jest-runtime/node_modules/strip-bom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/jest-snapshot": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
@@ -15889,6 +16410,23 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-snapshot/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -15905,6 +16443,23 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-util/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-util/node_modules/ci-info": {
@@ -15967,6 +16522,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/jest-validate/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/jest-watcher": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
@@ -15987,33 +16559,21 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-watcher/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+        "node_modules/jest-watcher/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "type-fest": "^0.21.3"
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
             },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/jest-worker": {
@@ -16059,9 +16619,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+            "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -16098,9 +16658,9 @@
             }
         },
         "node_modules/jsdoc-type-pratt-parser": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-            "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.3.0.tgz",
+            "integrity": "sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.0.0"
@@ -16152,48 +16712,6 @@
                 }
             }
         },
-        "node_modules/jsdom/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/jsdom/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/jsdom/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -16243,9 +16761,9 @@
             "license": "MIT"
         },
         "node_modules/json-with-bigint": {
-            "version": "3.5.8",
-            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+            "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
             "license": "MIT",
             "peer": true
         },
@@ -16416,14 +16934,13 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "17.0.8",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
-            "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
+            "version": "17.2.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
+            "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "listr2": "^10.2.1",
-                "picomatch": "^4.0.4",
+                "picomatch": "^4.0.5",
                 "string-argv": "^0.3.2",
                 "tinyexec": "^1.2.4"
             },
@@ -16440,119 +16957,17 @@
                 "yaml": "^2.9.0"
             }
         },
-        "node_modules/lint-staged/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+        "node_modules/lint-staged/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/lint-staged/node_modules/cli-truncate": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
-            "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "slice-ansi": "^8.0.0",
-                "string-width": "^8.2.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "get-east-asian-width": "^1.3.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/lint-staged/node_modules/listr2": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
-            "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "cli-truncate": "^5.2.0",
-                "eventemitter3": "^5.0.4",
-                "log-update": "^6.1.0",
-                "rfdc": "^1.4.1",
-                "wrap-ansi": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=22.13.0"
-            }
-        },
-        "node_modules/lint-staged/node_modules/slice-ansi": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-            "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^6.2.3",
-                "is-fullwidth-code-point": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
-        "node_modules/lint-staged/node_modules/string-width": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/lint-staged/node_modules/wrap-ansi": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-            "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-styles": "^6.2.3",
-                "string-width": "^8.2.0",
-                "strip-ansi": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/listr2": {
@@ -16584,6 +16999,22 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/listr2/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/listr2/node_modules/wrap-ansi": {
@@ -16714,6 +17145,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/log-symbols/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/log-update": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -16725,6 +17173,21 @@
                 "slice-ansi": "^7.1.0",
                 "strip-ansi": "^7.1.0",
                 "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/ansi-escapes": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -16774,6 +17237,21 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/log-update/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/log-update/node_modules/wrap-ansi": {
@@ -17186,13 +17664,30 @@
             "license": "CC0-1.0"
         },
         "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/meow": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+            "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/merge-descriptors": {
@@ -18147,9 +18642,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -18225,6 +18720,19 @@
             },
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/new-github-release-url/node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "license": "(MIT OR CC0-1.0)",
+            "peer": true,
+            "engines": {
+                "node": ">=12.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -18370,9 +18878,9 @@
             "peer": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -18673,6 +19181,56 @@
                 }
             }
         },
+        "node_modules/nx/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nx/node_modules/balanced-match": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+            "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/nx/node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/nx/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/nx/node_modules/cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -18684,6 +19242,39 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/nx/node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/nx/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/nx/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/nx/node_modules/restore-cursor": {
@@ -18720,6 +19311,19 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/nx/node_modules/smol-toml": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/cyyynthia"
+            }
+        },
         "node_modules/nx/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -18735,17 +19339,45 @@
                 "node": ">=8"
             }
         },
-        "node_modules/nx/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+        "node_modules/nx/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/nx/node_modules/tsconfig-paths": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^5.0.1"
+                "json5": "^2.2.2",
+                "minimist": "^1.2.6",
+                "strip-bom": "^3.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=6"
+            }
+        },
+        "node_modules/nx/node_modules/which": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+            "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/nx/node_modules/wrap-ansi": {
@@ -18767,9 +19399,9 @@
             }
         },
         "node_modules/nypm": {
-            "version": "0.6.7",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
-            "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.9.tgz",
+            "integrity": "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -19011,6 +19643,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/ora/node_modules/cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -19045,19 +19694,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/ora/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/os-name": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
@@ -19076,12 +19712,13 @@
             }
         },
         "node_modules/own-keys": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+            "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.6",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
                 "object-keys": "^1.1.1",
                 "safe-push-apply": "^1.0.0"
             },
@@ -19123,9 +19760,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-            "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -19979,9 +20616,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "license": "MIT",
             "peer": true,
             "bin": {
@@ -20055,6 +20692,23 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/prettier-package-json/node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prettier-package-json/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -20096,6 +20750,16 @@
             "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/prettier-package-json/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "license": "ISC",
+            "peer": true,
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/prettier-plugin-organize-attributes": {
             "version": "1.0.0",
@@ -20409,13 +21073,17 @@
             "peer": true
         },
         "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/raw-body": {
@@ -20617,9 +21285,9 @@
             }
         },
         "node_modules/release-it": {
-            "version": "20.2.0",
-            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.0.tgz",
-            "integrity": "sha512-9ZTk9ripgctC6VTqH+P54KuboK29A5mG/I3tFfS5hnoAnkwtFFAMHRidYz93ylrW995vF50Ny1aOGJiyRmEN7w==",
+            "version": "20.2.1",
+            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+            "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
             "funding": [
                 {
                     "type": "github",
@@ -20652,7 +21320,7 @@
                 "proxy-agent": "7.0.0",
                 "semver": "7.7.4",
                 "tinyglobby": "0.2.15",
-                "undici": "7.24.5",
+                "undici": "7.28.0",
                 "url-join": "5.0.0",
                 "wildcard-match": "5.1.4",
                 "yargs-parser": "22.0.0"
@@ -21008,19 +21676,6 @@
                 }
             }
         },
-        "node_modules/release-it/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
         "node_modules/release-it/node_modules/cli-spinners": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -21214,6 +21869,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/release-it/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/release-it/node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -21306,7 +21977,7 @@
                 "node": ">=8"
             }
         },
-        "node_modules/resolve-cwd/node_modules/resolve-from": {
+        "node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -21314,15 +21985,6 @@
             "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/resolve.exports": {
@@ -21938,10 +22600,11 @@
             }
         },
         "node_modules/smol-toml": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+            "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">= 18"
             },
@@ -21983,6 +22646,15 @@
                 "debug": "^4.3.4",
                 "socks": "^2.8.3"
             },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/socks-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -22053,11 +22725,11 @@
             }
         },
         "node_modules/source-map-support": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-            "dev": true,
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -22067,8 +22739,8 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -22229,19 +22901,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/string-length/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/string-width": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -22275,24 +22934,26 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/string-width/node_modules/emoji-regex": {
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
             "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "license": "MIT"
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
         },
         "node_modules/string.prototype.trim": {
             "version": "1.2.11",
@@ -22316,18 +22977,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/string.prototype.trim/node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
@@ -22344,18 +22993,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimend/node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/string.prototype.trimstart": {
@@ -22376,18 +23013,15 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.2.2"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/strip-ansi-cjs": {
@@ -22404,25 +23038,33 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-ansi/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
@@ -22466,9 +23108,9 @@
             "license": "ISC"
         },
         "node_modules/stylelint": {
-            "version": "17.13.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
-            "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
+            "version": "17.14.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+            "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -22484,21 +23126,21 @@
             "dependencies": {
                 "@csstools/css-calc": "^3.2.1",
                 "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
                 "@csstools/css-tokenizer": "^4.0.0",
                 "@csstools/media-query-list-parser": "^5.0.0",
                 "@csstools/selector-resolve-nested": "^4.0.0",
                 "@csstools/selector-specificity": "^6.0.0",
                 "colord": "^2.9.3",
-                "cosmiconfig": "^9.0.1",
+                "cosmiconfig": "^9.0.2",
                 "css-functions-list": "^3.3.3",
                 "css-tree": "^3.2.1",
                 "debug": "^4.4.3",
                 "fast-glob": "^3.3.3",
                 "fastest-levenshtein": "^1.0.16",
-                "file-entry-cache": "^11.1.3",
+                "file-entry-cache": "^11.1.5",
                 "global-modules": "^2.0.0",
-                "globby": "^16.2.0",
+                "globby": "^16.2.1",
                 "globjoin": "^0.1.4",
                 "html-tags": "^5.1.0",
                 "ignore": "^7.0.5",
@@ -22508,12 +23150,12 @@
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.1.1",
-                "postcss": "^8.5.15",
+                "postcss": "^8.5.16",
                 "postcss-safe-parser": "^7.0.1",
-                "postcss-selector-parser": "^7.1.1",
+                "postcss-selector-parser": "^7.1.4",
                 "postcss-value-parser": "^4.2.0",
                 "string-width": "^8.2.1",
-                "supports-hyperlinks": "^4.4.0",
+                "supports-hyperlinks": "^4.5.0",
                 "svg-tags": "^1.0.0",
                 "table": "^6.9.0",
                 "write-file-atomic": "^7.0.1"
@@ -22676,33 +23318,6 @@
                 "stylelint": ">= 11 < 18"
             }
         },
-        "node_modules/stylelint/node_modules/cosmiconfig": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "env-paths": "^2.2.1",
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/stylelint/node_modules/file-entry-cache": {
             "version": "11.1.5",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
@@ -22725,17 +23340,43 @@
                 "hookified": "^1.15.0"
             }
         },
-        "node_modules/stylelint/node_modules/meow": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-            "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+        "node_modules/stylelint/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">=20"
+                "node": ">= 4"
+            }
+        },
+        "node_modules/stylelint/node_modules/postcss": {
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "nanoid": "^3.3.16",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/stylelint/node_modules/string-width": {
@@ -22753,6 +23394,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/stylelint/node_modules/write-file-atomic": {
@@ -22918,19 +23575,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/table/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -23228,9 +23872,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.4.11",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-            "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+            "version": "29.4.12",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+            "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -23240,7 +23884,7 @@
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.8.0",
+                "semver": "^7.8.5",
                 "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
@@ -23351,18 +23995,36 @@
             }
         },
         "node_modules/tsconfig-paths": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-            "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-            "dev": true,
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "license": "MIT",
             "dependencies": {
-                "json5": "^2.2.2",
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.2",
                 "minimist": "^1.2.6",
                 "strip-bom": "^3.0.0"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/json5": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.0"
             },
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/tsconfig-paths/node_modules/strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+            "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": ">=4"
             }
         },
         "node_modules/tslib": {
@@ -23409,13 +24071,13 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "license": "(MIT OR CC0-1.0)",
             "peer": true,
             "engines": {
-                "node": ">=12.20"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -23584,6 +24246,42 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/uglify-js": {
             "version": "3.19.3",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -23617,9 +24315,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -24056,19 +24754,18 @@
             }
         },
         "node_modules/which": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-            "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-            "dev": true,
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
             "bin": {
-                "node-which": "bin/which.js"
+                "node-which": "bin/node-which"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": ">= 8"
             }
         },
         "node_modules/which-boxed-primitive": {
@@ -24245,19 +24942,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/wrap-ansi/node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -24268,19 +24952,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -24314,9 +24985,9 @@
             "peer": true
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -24482,18 +25153,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/yn": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -24517,9 +25176,9 @@
             }
         },
         "node_modules/yoctocolors": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -25441,6 +26100,16 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "projects/eslint-plugin-experience-next/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "projects/eslint-plugin-experience-next/node_modules/ajv": {
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -25515,16 +26184,20 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "projects/eslint-plugin-experience-next/node_modules/chalk": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+        "projects/eslint-plugin-experience-next/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "extraneous": true,
             "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
             "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+                "node": ">= 20.19.0"
             },
             "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/chownr": {
@@ -25616,24 +26289,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "projects/eslint-plugin-experience-next/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "license": "BlueOak-1.0.0",
-            "peer": true,
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "projects/eslint-plugin-experience-next/node_modules/hosted-git-info": {
             "version": "9.0.3",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
@@ -25645,6 +26300,43 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "projects/eslint-plugin-experience-next/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "projects/eslint-plugin-experience-next/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "projects/eslint-plugin-experience-next/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/ignore-walk": {
@@ -26070,6 +26762,20 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "projects/eslint-plugin-experience-next/node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "extraneous": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "projects/eslint-plugin-experience-next/node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -26149,6 +26855,21 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "projects/eslint-plugin-experience-next/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "projects/eslint-plugin-experience-next/node_modules/tar": {
@@ -26374,23 +27095,6 @@
             },
             "bin": {
                 "syncer": "bin/src/index.js"
-            }
-        },
-        "projects/syncer/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "projects/tsconfig": {

--- a/projects/commitlint-config/package.json
+++ b/projects/commitlint-config/package.json
@@ -46,11 +46,10 @@
     "module": "./index.esm.js",
     "types": "./index.d.ts",
     "dependencies": {
-        "@commitlint/config-conventional": "21.1.0",
-        "conventional-changelog-conventionalcommits": "9.3.1"
+        "@commitlint/config-conventional": "21.2.0"
     },
     "peerDependencies": {
-        "@commitlint/cli": "^21.1.0",
+        "@commitlint/cli": "^21.2.0",
         "lint-staged": "^17.0.8"
     },
     "publishConfig": {

--- a/projects/eslint-plugin-experience-next/docs/no-infinite-loop.md
+++ b/projects/eslint-plugin-experience-next/docs/no-infinite-loop.md
@@ -33,7 +33,7 @@ for (;;) {
 }
 
 // ✅ ok
-for (; queue.length > 0; ) {
+for (; queue.length > 0;) {
   flush(queue.shift());
 }
 ```

--- a/projects/eslint-plugin-experience-next/rules/recommended/no-empty-style-metadata.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/no-empty-style-metadata.ts
@@ -63,12 +63,10 @@ export const rule = createRule<Options, MessageIds>({
                                       metadata.range,
                                       removeRanges(
                                           sourceCode.text.slice(...metadata.range),
-                                          ranges.map(
-                                              ([start, end]): Range => [
-                                                  start - metadata.range[0],
-                                                  end - metadata.range[0],
-                                              ],
-                                          ),
+                                          ranges.map(([start, end]): Range => [
+                                              start - metadata.range[0],
+                                              end - metadata.range[0],
+                                          ]),
                                       ),
                                   );
                         },

--- a/projects/eslint-plugin-experience-next/rules/recommended/no-side-effects-in-computed.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/no-side-effects-in-computed.ts
@@ -254,8 +254,7 @@ function resolveCalledFunctions(
     const resolved = new Map<string, FunctionLikeScope>();
 
     const tsNode = context.esTreeNodeToTSNodeMap.get(node) as
-        | ts.CallLikeExpression
-        | undefined;
+        ts.CallLikeExpression | undefined;
 
     const signature = tsNode ? context.checker.getResolvedSignature(tsNode) : undefined;
     const declarations = new Set<ts.Declaration>();

--- a/projects/eslint-plugin-experience-next/rules/recommended/no-string-literal-concat.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/no-string-literal-concat.ts
@@ -109,8 +109,7 @@ export const rule = createRule<Options, MessageId>({
             }
 
             const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node) as unknown as
-                | ts.Node
-                | undefined;
+                ts.Node | undefined;
 
             return tsNode
                 ? isStringType(checker.getTypeAtLocation(tsNode), checker)

--- a/projects/eslint-plugin-experience-next/rules/recommended/object-single-line.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/object-single-line.ts
@@ -192,8 +192,7 @@ export const rule = createRule<Options, MessageIds>({
 
                 if (bodyAny?.type === 'ParenthesizedExpression') {
                     const bodyInner = bodyAny.expression as
-                        | TSESTree.Expression
-                        | undefined;
+                        TSESTree.Expression | undefined;
 
                     if (bodyInner) {
                         const inner = unwrapExpression(bodyInner);

--- a/projects/eslint-plugin-experience-next/rules/utils/angular/angular-signals.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/angular/angular-signals.ts
@@ -30,8 +30,7 @@ const AFTER_RENDER_EFFECT_PHASES = new Map([
 ]);
 
 export type ReactiveCallback =
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionExpression;
+    TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
 
 export interface ReactiveScope {
     readonly callback: ReactiveCallback;

--- a/projects/eslint-plugin-experience-next/rules/utils/angular/element-attributes.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/angular/element-attributes.ts
@@ -8,10 +8,7 @@ import {
 } from '@angular-eslint/bundled-angular-compiler';
 
 export type ElementAttributeLike =
-    | TmplAstBoundAttribute
-    | TmplAstBoundEvent
-    | TmplAstReference
-    | TmplAstTextAttribute;
+    TmplAstBoundAttribute | TmplAstBoundEvent | TmplAstReference | TmplAstTextAttribute;
 
 export type ElementAttributeName = string | readonly string[];
 

--- a/projects/eslint-plugin-experience-next/rules/utils/ast/ast-walk.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/ast/ast-walk.ts
@@ -1,8 +1,7 @@
 import {AST_NODE_TYPES, type TSESTree} from '@typescript-eslint/utils';
 
 export type FunctionExpressionLike =
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionExpression;
+    TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression;
 
 export function isFunctionExpressionLike(
     node: TSESTree.Node | null | undefined,

--- a/projects/eslint-plugin-experience-next/rules/utils/ast/class-members.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/ast/class-members.ts
@@ -10,8 +10,7 @@ export {
 } from './spacing';
 
 export type FieldLikeMember =
-    | TSESTree.PropertyDefinition
-    | TSESTree.TSAbstractPropertyDefinition;
+    TSESTree.PropertyDefinition | TSESTree.TSAbstractPropertyDefinition;
 
 export type AccessibilityGroup = 'private' | 'protected' | 'public';
 

--- a/projects/eslint-plugin-experience-next/rules/utils/ast/comma-separated.ts
+++ b/projects/eslint-plugin-experience-next/rules/utils/ast/comma-separated.ts
@@ -3,9 +3,7 @@ import {type TSESLint, type TSESTree} from '@typescript-eslint/utils';
 import {getLineStartOffset, getNextLineStartOffset} from './spacing';
 
 export type CommaSeparatedNode =
-    | TSESTree.Expression
-    | TSESTree.Property
-    | TSESTree.SpreadElement;
+    TSESTree.Expression | TSESTree.Property | TSESTree.SpreadElement;
 
 function getCommaAfter(
     sourceCode: Readonly<TSESLint.SourceCode>,

--- a/projects/eslint-plugin-experience-next/tests/no-infinite-loop.spec.ts
+++ b/projects/eslint-plugin-experience-next/tests/no-infinite-loop.spec.ts
@@ -75,7 +75,7 @@ ruleTester.run('no-infinite-loop', rule, {
         },
         {
             code: /* TypeScript */ `
-                for (; isRunning; ) {
+                for (; isRunning;) {
                     process();
                 }
             `,

--- a/projects/release-it-config/package.json
+++ b/projects/release-it-config/package.json
@@ -34,7 +34,7 @@
     ],
     "main": ".release-it.js",
     "peerDependencies": {
-        "@release-it/conventional-changelog": "^11.0.1",
+        "@release-it/conventional-changelog": "^12.0.0",
         "@taiga-ui/auto-changelog-config": "^0.554.0",
         "release-it": "^20.2.0"
     },

--- a/projects/stylelint-config/rules/no-mask-shorthand.ts
+++ b/projects/stylelint-config/rules/no-mask-shorthand.ts
@@ -4,14 +4,7 @@ import stylelint from 'stylelint';
 type ValueNode = valueParser.Node;
 
 type MaskLayerKey =
-    | 'clip'
-    | 'composite'
-    | 'image'
-    | 'mode'
-    | 'origin'
-    | 'position'
-    | 'repeat'
-    | 'size';
+    'clip' | 'composite' | 'image' | 'mode' | 'origin' | 'position' | 'repeat' | 'size';
 
 interface ValueTerm {
     readonly nodes: ValueNode[];

--- a/projects/syncer/src/sync-versions.ts
+++ b/projects/syncer/src/sync-versions.ts
@@ -86,9 +86,7 @@ export function tuiBumpDeps(options: BumpDepsOptions): void {
         }),
     )) {
         const value = deps[key] as
-            | Record<string, Record<string, string>>
-            | string
-            | undefined;
+            Record<string, Record<string, string>> | string | undefined;
 
         if (typeof value === 'string') {
             deps[key] = isPeerDependency


### PR DESCRIPTION
### Problem
Maskito [Release job](https://github.com/taiga-family/maskito/actions/runs/31587340788/job/94084124075) fails with error

```
> Run export GITHUB_TOKEN="***"
  $ git fetch --prune --prune-tags origin > /dev/null || echo ""
  WARNING The recommended bump is "minor", but is overridden with "minor".
  ERROR Cannot find package 'conventional-commits-filter' imported from
/.../maskito/node_modules/conventional-changelog/node_modules/@conventional-changelog/git-client/dist/ConventionalGitClient.js
```

Relates:
- https://github.com/conventional-changelog/conventional-changelog/pull/1536

### Previous behavior
(inside maskito repo)
```bash
pkg=conventional-commits-filter
find node_modules -type d \( -path "*/node_modules/$pkg" -o -path "node_modules/$pkg" \) |
    tree --fromfile . --noreport
```

```
.
└── node_modules
    ├── conventional-changelog-writer
    │   └── node_modules
    │       └── conventional-commits-filter
    └── conventional-recommended-bump
        └── node_modules
            └── conventional-commits-filter
```

## New behavior
(same bash script inside maskito repo)
```
.
└── node_modules
    └── conventional-commits-filter
```

Tested locally using npm `overrides` 
```json
"overrides": {
    "@release-it/conventional-changelog": "^12.0.0"
},
```
