### PR TITLE
fix: `single-line-variable-spacing` require blank line only after multiline declarations, not before

### DIFF
--- a/projects/eslint-plugin-experience-next/docs/single-line-variable-spacing.md
+++ b/projects/eslint-plugin-experience-next/docs/single-line-variable-spacing.md
@@ -2,11 +2,12 @@
 
 <sup>`✅ Recommended`</sup> <sup>`Fixable`</sup>
 
-Keeps consecutive single-line variable declarations visually grouped. A multiline variable declaration must be separated
-from neighboring variable declarations with a blank line before it and, when another variable follows, a blank line
-after it. Exported and non-exported variable declarations are separate visual groups. Variable declarations initialized
-with direct `require(...)` or dynamic `import(...)` calls are ignored as import boundaries, so the rule does not add or
-remove blank lines around them.
+Keeps consecutive single-line variable declarations visually grouped. When another variable declaration follows a
+multiline variable declaration, it must be separated from that declaration with a blank line after it; a blank line
+before a multiline variable declaration is not required. Exported and non-exported variable declarations are separate
+visual groups and must still be separated by a blank line. Variable declarations initialized with direct `require(...)`
+or dynamic `import(...)` calls are ignored as import boundaries, so the rule does not add or remove blank lines around
+them.
 
 ```ts
 // ❌ error
@@ -19,7 +20,6 @@ let c = 3;
 
 // ✅ after autofix
 let a = 1;
-
 const b = Math.max(
   validatedTimeStringLooooooooooongvalidatedTimeStringLooooooooooong.length - value.length - paddedZeroes,
   0,

--- a/projects/eslint-plugin-experience-next/rules/recommended/single-line-variable-spacing.ts
+++ b/projects/eslint-plugin-experience-next/rules/recommended/single-line-variable-spacing.ts
@@ -11,7 +11,6 @@ import {createRule} from '../utils/create-rule';
 
 type MessageIds =
     | 'missingBlankLineAfterMultilineVariable'
-    | 'missingBlankLineBeforeMultilineVariable'
     | 'missingBlankLineBetweenVariableGroups'
     | 'unexpectedBlankLineBeforeNextSingleLineVariable';
 
@@ -145,12 +144,7 @@ export const rule = createRule<[], MessageIds>({
                     continue;
                 }
 
-                if (
-                    currentIsSingleLine &&
-                    nextIsSingleLine &&
-                    !sameExportGroup &&
-                    !blankLineBetween
-                ) {
+                if (currentIsSingleLine && !sameExportGroup && !blankLineBetween) {
                     context.report({
                         fix: (fixer) =>
                             fixer.replaceTextRange(
@@ -163,23 +157,6 @@ export const rule = createRule<[], MessageIds>({
                                 ),
                             ),
                         messageId: 'missingBlankLineBetweenVariableGroups',
-                        node: next.node,
-                    });
-                }
-
-                if (currentIsSingleLine && !nextIsSingleLine && !blankLineBetween) {
-                    context.report({
-                        fix: (fixer) =>
-                            fixer.replaceTextRange(
-                                [current.node.range[1], next.node.range[0]],
-                                getSpacingReplacement(
-                                    sourceCode,
-                                    betweenText,
-                                    next.node.loc.start.line,
-                                    1,
-                                ),
-                            ),
-                        messageId: 'missingBlankLineBeforeMultilineVariable',
                         node: next.node,
                     });
 
@@ -236,8 +213,6 @@ export const rule = createRule<[], MessageIds>({
         messages: {
             missingBlankLineAfterMultilineVariable:
                 'Multiline variable declarations should be followed by a blank line before the next variable declaration',
-            missingBlankLineBeforeMultilineVariable:
-                'Multiline variable declarations should be preceded by a blank line after single-line variable declarations',
             missingBlankLineBetweenVariableGroups:
                 'Exported and non-exported variable declarations should be separated by a blank line',
             unexpectedBlankLineBeforeNextSingleLineVariable:

--- a/projects/eslint-plugin-experience-next/tests/single-line-variable-spacing.spec.ts
+++ b/projects/eslint-plugin-experience-next/tests/single-line-variable-spacing.spec.ts
@@ -23,13 +23,9 @@ ruleTester.run('single-line-variable-spacing', rule, {
                 );
                 let c = 3;
             `,
-            errors: [
-                {messageId: 'missingBlankLineBeforeMultilineVariable'},
-                {messageId: 'missingBlankLineAfterMultilineVariable'},
-            ],
+            errors: [{messageId: 'missingBlankLineAfterMultilineVariable'}],
             output: `
                 let a = 1;
-
                 const b = Math.max(
                     validatedTimeString.length - value.length - paddedZeroes,
                     0,
@@ -178,28 +174,20 @@ ruleTester.run('single-line-variable-spacing', rule, {
         },
         {
             code: `
-                class Example {
-                    static {
-                        const a = 1;
-                        const b = Math.max(
-                            value,
-                            0,
-                        );
-                    }
-                }
+                export const a = 1;
+                const b = Math.max(
+                    value,
+                    0,
+                );
             `,
-            errors: [{messageId: 'missingBlankLineBeforeMultilineVariable'}],
+            errors: [{messageId: 'missingBlankLineBetweenVariableGroups'}],
             output: `
-                class Example {
-                    static {
-                        const a = 1;
+                export const a = 1;
 
-                        const b = Math.max(
-                            value,
-                            0,
-                        );
-                    }
-                }
+                const b = Math.max(
+                    value,
+                    0,
+                );
             `,
         },
         {
@@ -289,6 +277,30 @@ ruleTester.run('single-line-variable-spacing', rule, {
                 );
 
                 let c = 3;
+            `,
+        },
+        {
+            code: /* TypeScript */ `
+                let a = 1;
+                const b = Math.max(
+                    validatedTimeString.length - value.length - paddedZeroes,
+                    0,
+                );
+
+                let c = 3;
+            `,
+        },
+        {
+            code: `
+                class Example {
+                    static {
+                        const a = 1;
+                        const b = Math.max(
+                            value,
+                            0,
+                        );
+                    }
+                }
             `,
         },
         {


### PR DESCRIPTION
Same change as #1958, but for `single-line-variable-spacing`.

- Removed the `missingBlankLineBeforeMultilineVariable` message and its branch: a blank line **before** a multiline
  variable declaration is no longer required (it is still allowed). Only a blank line **after** a multiline declaration
  is enforced.
- Relaxed `missingBlankLineBetweenVariableGroups` to drop the `nextIsSingleLine` requirement. Without it the
  export / non-export boundary would silently stop being checked when the next declaration is multiline — that case used
  to be covered by the removed branch.
- Updated tests and `docs/single-line-variable-spacing.md` accordingly.

Verified with `npx jest projects/eslint-plugin-experience-next` (987 tests), `nx run eslint-plugin-experience-next:build`,
`eslint .` over the whole repo and prettier — all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FkAYS4bRfezEPJPmnrviT)_